### PR TITLE
Add VPC network configuration for Cloud Run Jobs

### DIFF
--- a/docs/cloud-jobs.md
+++ b/docs/cloud-jobs.md
@@ -213,11 +213,11 @@ cloud: {
 
 This passes `--network`, `--subnet`, and `--vpc-egress` flags to `gcloud run jobs create/update`, enabling your Cloud Run Job containers to reach private IPs within the VPC.
 
-| Option   | Description                          | Default                  |
-| -------- | ------------------------------------ | ------------------------ |
-| `name`   | VPC network name                     | _(required)_             |
-| `subnet` | VPC subnet name                      | _(not set)_              |
-| `egress` | VPC egress mode                      | `"private-ranges-only"`  |
+| Option   | Description      | Default                 |
+| -------- | ---------------- | ----------------------- |
+| `name`   | VPC network name | _(required)_            |
+| `subnet` | VPC subnet name  | _(not set)_             |
+| `egress` | VPC egress mode  | `"private-ranges-only"` |
 
 The `egress` option controls which traffic is routed through the VPC:
 

--- a/docs/cloud-jobs.md
+++ b/docs/cloud-jobs.md
@@ -189,8 +189,40 @@ cloud: {
     timeout: 7200,                // Optional, default: 86400 seconds (24 hours)
     parallelism: 5,               // Optional, max concurrent tasks
   },
+  network: {
+    name: "default",              // VPC network name
+    subnet: "default",            // Optional, VPC subnet name
+    egress: "private-ranges-only", // Optional, default: "private-ranges-only"
+  },
 }
 ```
+
+## VPC Network Access
+
+If your jobs need to access resources on a private network (e.g., a Redis instance or internal database), configure Direct VPC egress with the `network` option:
+
+```typescript
+cloud: {
+  name: "my-service-jobs",
+  network: {
+    name: "default",
+    subnet: "default",
+  },
+},
+```
+
+This passes `--network`, `--subnet`, and `--vpc-egress` flags to `gcloud run jobs create/update`, enabling your Cloud Run Job containers to reach private IPs within the VPC.
+
+| Option   | Description                          | Default                  |
+| -------- | ------------------------------------ | ------------------------ |
+| `name`   | VPC network name                     | _(required)_             |
+| `subnet` | VPC subnet name                      | _(not set)_              |
+| `egress` | VPC egress mode                      | `"private-ranges-only"`  |
+
+The `egress` option controls which traffic is routed through the VPC:
+
+- `"private-ranges-only"` — only traffic to private IP ranges (RFC 1918) goes through the VPC
+- `"all-traffic"` — all outbound traffic is routed through the VPC
 
 ## Example Job
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,6 +108,10 @@ export default defineRunnerConfig({
       timeout: 7200, // Optional, default: 86400 (24 hours)
       parallelism: 5, // Optional, max concurrent tasks
     },
+    network: {
+      name: "default", // VPC network name
+      subnet: "default", // Optional, VPC subnet name
+    },
   },
 });
 ```

--- a/src/cloud/deploy.ts
+++ b/src/cloud/deploy.ts
@@ -409,6 +409,16 @@ export async function createOrUpdateJob(
       updateArgs.push(`--service-account=${cloud.serviceAccount}`);
     }
 
+    if (cloud.network) {
+      updateArgs.push(`--network=${cloud.network.name}`);
+      if (cloud.network.subnet) {
+        updateArgs.push(`--subnet=${cloud.network.subnet}`);
+      }
+      updateArgs.push(
+        `--vpc-egress=${cloud.network.egress ?? "private-ranges-only"}`,
+      );
+    }
+
     const result = gcloudExecCapture(updateArgs);
 
     if (!result.success) {
@@ -454,6 +464,16 @@ export async function createOrUpdateJob(
 
   if (cloud.serviceAccount) {
     createArgs.push(`--service-account=${cloud.serviceAccount}`);
+  }
+
+  if (cloud.network) {
+    createArgs.push(`--network=${cloud.network.name}`);
+    if (cloud.network.subnet) {
+      createArgs.push(`--subnet=${cloud.network.subnet}`);
+    }
+    createArgs.push(
+      `--vpc-egress=${cloud.network.egress ?? "private-ranges-only"}`,
+    );
   }
 
   const result = gcloudExecCapture(createArgs);

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,16 @@ export interface CloudResources {
   parallelism?: number;
 }
 
+/** Direct VPC egress configuration for private network access (e.g., Redis) */
+export interface CloudNetworkConfig {
+  /** VPC network name (e.g., "default") */
+  name: string;
+  /** VPC subnet name (e.g., "default") */
+  subnet?: string;
+  /** VPC egress mode. Default: "private-ranges-only" */
+  egress?: "all-traffic" | "private-ranges-only";
+}
+
 /** Configuration for Cloud Run Jobs execution */
 export interface CloudConfig {
   /** Cloud Run Job name (e.g., "loads-predictions-jobs") */
@@ -37,6 +47,8 @@ export interface CloudConfig {
    * Requires Docker to be installed and running. Default: true.
    */
   buildLocal?: boolean;
+  /** Direct VPC egress configuration for private network access */
+  network?: CloudNetworkConfig;
 }
 
 /** Full runner configuration provided by each service */

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export { runJob } from "./run-job";
 export type { TaskContext } from "./task-context";
 export type {
   CloudConfig,
+  CloudNetworkConfig,
   CloudResources,
   RunnerConfig,
   RunnerEnvOptions,


### PR DESCRIPTION
## Summary

- Add `network` option to `CloudConfig` for Direct VPC egress configuration
- Pass `--network`, `--subnet`, and `--vpc-egress` flags to `gcloud run jobs create/update` when configured
- Document the new option in `cloud-jobs.md` and `configuration.md`

This enables Cloud Run Jobs to reach private network resources (e.g., Redis, internal databases) by configuring VPC egress.

## Example

```typescript
cloud: {
  name: "my-service-jobs",
  network: {
    name: "default",
    subnet: "default",
  },
},
```