### PR TITLE
Add envFile option to RunnerEnvOptions

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,7 @@ import { discoverJobs } from "./discover-jobs";
 import { promptForArgs, selectJob } from "./interactive";
 import { runJob } from "./run-job";
 import { getSecrets } from "./secrets";
+import { parseEnvFiles } from "./env-file";
 import type { JobFunction } from "./types";
 
 const BIN_NAME = "job";
@@ -295,15 +296,24 @@ async function handleLocalRun(options: LocalRunOptions): Promise<void> {
 
   /** Set environment variables for local execution */
   process.env.NODE_ENV ??= "development";
-  process.env.GOOGLE_CLOUD_PROJECT = envConfig.project;
   process.env.USE_CONSOLE_LOG ??= "true";
   process.env.LOG_COLORIZE ??= "true";
 
+  /** Load envFile variables (don't overwrite existing process.env values) */
+  const envFileVars = parseEnvFiles(envConfig.envFile);
+  for (const [key, value] of Object.entries(envFileVars)) {
+    process.env[key] ??= value;
+  }
+
+  /** Explicit env values override envFile values */
   if (envConfig.env) {
     for (const [key, value] of Object.entries(envConfig.env)) {
       process.env[key] = value;
     }
   }
+
+  /** Project always takes highest precedence */
+  process.env.GOOGLE_CLOUD_PROJECT = envConfig.project;
 
   if (envConfig.secrets && envConfig.secrets.length > 0) {
     const secrets = await getSecrets(envConfig.secrets);

--- a/src/cloud/deploy.ts
+++ b/src/cloud/deploy.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
 import path from "node:path";
 import { consola } from "consola";
 import type { CloudConfig, RunnerEnvOptions } from "../config";
+import { parseEnvFiles } from "../env-file";
 import { generateDockerfile } from "./dockerfile";
 import {
   checkGcloudAvailable,
@@ -359,10 +360,12 @@ export async function createOrUpdateJob(
     { ignoreErrors: true },
   );
 
-  /** Build environment variables */
+  /** Build environment variables (envFile < env < project) */
+  const envFileVars = parseEnvFiles(envConfig.envFile);
   const envVars: Record<string, string> = {
-    GOOGLE_CLOUD_PROJECT: project,
+    ...envFileVars,
     ...envConfig.env,
+    GOOGLE_CLOUD_PROJECT: project,
   };
 
   const envVarsString = Object.entries(envVars)

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,12 @@
 export interface RunnerEnvOptions {
   /** GCP project ID — sets GOOGLE_CLOUD_PROJECT automatically */
   project: string;
+  /**
+   * Path(s) to .env files to load, resolved relative to the service directory.
+   * Variables from these files have lower precedence than explicit `env` values.
+   * When multiple files are specified, earlier files take precedence over later ones.
+   */
+  envFile?: string | string[];
   /** Additional environment variables to set before the job runs */
   env?: Record<string, string>;
   /** Secret names to load from GCP Secret Manager */

--- a/src/env-file.test.ts
+++ b/src/env-file.test.ts
@@ -1,0 +1,86 @@
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { parseEnvFiles } from "./env-file";
+
+describe("parseEnvFiles", () => {
+  let tempDir: string;
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "env-file-test-"));
+
+    writeFileSync(
+      path.join(tempDir, ".env.stag"),
+      [
+        "# Staging config",
+        "API_URL=https://api.staging.example.com",
+        "DB_HOST=staging-db",
+        "SHARED=from-stag",
+        "",
+        "EMPTY_VALUE=",
+      ].join("\n"),
+    );
+
+    writeFileSync(
+      path.join(tempDir, ".env.prod"),
+      [
+        "API_URL=https://api.example.com",
+        "DB_HOST=prod-db",
+        "SHARED=from-prod",
+      ].join("\n"),
+    );
+
+    writeFileSync(
+      path.join(tempDir, ".env.local"),
+      ["SHARED=from-local", "LOCAL_ONLY=secret"].join("\n"),
+    );
+  });
+
+  afterAll(() => {
+    rmSync(tempDir, { recursive: true });
+  });
+
+  it("returns empty object when envFile is undefined", () => {
+    expect(parseEnvFiles(undefined)).toEqual({});
+  });
+
+  it("parses a single env file", () => {
+    const result = parseEnvFiles(".env.stag", tempDir);
+
+    expect(result).toEqual({
+      API_URL: "https://api.staging.example.com",
+      DB_HOST: "staging-db",
+      SHARED: "from-stag",
+      EMPTY_VALUE: "",
+    });
+  });
+
+  it("applies first-wins precedence across multiple files", () => {
+    const result = parseEnvFiles([".env.local", ".env.stag"], tempDir);
+
+    expect(result.SHARED).toBe("from-local");
+    expect(result.LOCAL_ONLY).toBe("secret");
+    expect(result.API_URL).toBe("https://api.staging.example.com");
+  });
+
+  it("throws when a file does not exist", () => {
+    expect(() => parseEnvFiles(".env.missing", tempDir)).toThrowError(
+      /Environment file not found: .env.missing/,
+    );
+  });
+
+  it("handles comments and blank lines", () => {
+    const result = parseEnvFiles(".env.stag", tempDir);
+
+    expect(Object.keys(result)).not.toContain("#");
+    expect(result.API_URL).toBe("https://api.staging.example.com");
+  });
+
+  it("accepts a single string instead of an array", () => {
+    const result = parseEnvFiles(".env.prod", tempDir);
+
+    expect(result.API_URL).toBe("https://api.example.com");
+    expect(result.DB_HOST).toBe("prod-db");
+  });
+});

--- a/src/env-file.ts
+++ b/src/env-file.ts
@@ -31,7 +31,7 @@ export function parseEnvFiles(
     const parsed = parseEnv(content);
 
     for (const [key, value] of Object.entries(parsed)) {
-      if (value !== undefined && !(key in result)) {
+      if (value !== undefined && !Object.hasOwn(result, key)) {
         result[key] = value;
       }
     }

--- a/src/env-file.ts
+++ b/src/env-file.ts
@@ -1,0 +1,41 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { parseEnv } from "node:util";
+
+/**
+ * Parse one or more .env files and return the merged key-value pairs.
+ *
+ * Files are processed in order. Earlier files take precedence over later ones
+ * (first-wins), matching the dotenv convention.
+ */
+export function parseEnvFiles(
+  envFile: string | string[] | undefined,
+  cwd?: string,
+): Record<string, string> {
+  if (!envFile) return {};
+
+  const files = Array.isArray(envFile) ? envFile : [envFile];
+  const baseDir = cwd ?? process.cwd();
+  const result: Record<string, string> = {};
+
+  for (const file of files) {
+    const filePath = path.resolve(baseDir, file);
+
+    if (!existsSync(filePath)) {
+      throw new Error(
+        `Environment file not found: ${file}\nResolved path: ${filePath}`,
+      );
+    }
+
+    const content = readFileSync(filePath, "utf-8");
+    const parsed = parseEnv(content);
+
+    for (const [key, value] of Object.entries(parsed)) {
+      if (value !== undefined && !(key in result)) {
+        result[key] = value;
+      }
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
Adds an `envFile` property to `RunnerEnvOptions` so environment variables can be loaded from `.env` files instead of being duplicated in the job-runner config.

### Problem

Services that use gcp-job-runner often already maintain per-environment `.env` files (e.g. `.env.stag`, `.env.prod`) for their regular runtime. The job-runner config then has to redeclare many of the same variables in the `env` object, creating duplication that drifts over time. Some services work around this by manually calling `process.loadEnvFile()` in their `initialize()` hook, but that only works for local execution — it doesn't help with cloud deployments where env vars are passed via `--set-env-vars`.

### Solution

`envFile` accepts a single path or an array of paths, resolved relative to the service directory (where `job-runner.config.ts` lives). The parsed variables are applied in both the local execution path (`process.env`) and the cloud deployment path (`--set-env-vars` flag to gcloud).

```typescript
defineRunnerEnv({
  project: "my-project",
  envFile: [".env.local.stag", ".env.stag"],
  env: { NODE_ENV: "production", SOME_OVERRIDE: "value" },
})
```

**Precedence (highest to lowest):**
1. `project` → `GOOGLE_CLOUD_PROJECT` (always wins)
2. Explicit `env` values (override everything below)
3. Existing `process.env` / shell environment (local execution only)
4. `envFile` values (don't overwrite existing vars, first file wins when multiple)

This matches the standard dotenv convention where `.env` files never overwrite existing environment variables. You can keep service-specific overrides in `env` while loading the bulk of config from existing `.env` files. When using multiple files, the order follows the dotenv convention — earlier files take precedence, so `.env.local.stag` can override values from `.env.stag`.

Uses Node's built-in `util.parseEnv` (stable since Node 20.12, well within the `>=22.6.0` engine requirement).

### Migration

When integrating this version in a consumer repo:
- Add `envFile` to `defineRunnerEnv()` calls in `job-runner.config.ts`, pointing to the existing `.env.{stag,prod}` files
- Remove any env vars from the explicit `env` object that are now covered by the env file
- Remove any manual `process.loadEnvFile()` workarounds from `initialize()` hooks or `src/env.ts`, since the framework now handles this
- Keep env vars in `env` that are job-runner-specific and not in the `.env` files (e.g. `NODE_ENV: "production"`)

Scope: gcp-job-runner
Visibility: user-facing