### PR TITLE
Add getExportsWriter for local and GCS artifact output

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Same code, same arguments, same secrets. The cloud command automatically builds 
 - **Cloud Run deployment** — no Terraform or manual GCP config needed, just `job cloud run`
 - **Smart caching** — a single Docker image contains all jobs; running different jobs or different arguments doesn't rebuild
 - **GCP Secret Manager** — secrets are loaded transparently for both local and cloud execution
+- **Unified artifact output** — `getExportsWriter()` writes JSON/CSV/binary to a local directory during development and to a Cloud Storage bucket in production, with the same handler code
 - **Multi-environment** — configure staging, production, etc. and switch with a single argument
 
 ## Install

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
           { text: "Getting Started", link: "/getting-started" },
           { text: "Configuration", link: "/configuration" },
           { text: "Defining Jobs", link: "/defining-jobs" },
+          { text: "Writing Exports", link: "/exports" },
           { text: "CLI Usage", link: "/cli-usage" },
         ],
       },

--- a/docs/cloud-jobs.md
+++ b/docs/cloud-jobs.md
@@ -30,10 +30,12 @@ export default defineRunnerConfig({
     stag: defineRunnerEnv({
       project: "my-project",
       secrets: ["API_KEY"],
+      exportsPath: "gs://my-project-stag-exports",
     }),
     prod: defineRunnerEnv({
       project: "my-project-prod",
       secrets: ["API_KEY"],
+      exportsPath: "gs://my-project-prod-exports",
     }),
   },
   cloud: {
@@ -41,6 +43,8 @@ export default defineRunnerConfig({
   },
 });
 ```
+
+`exportsPath` is optional — set it if your jobs produce artifacts via [`getExportsWriter()`](./exports). Cloud environments require a `gs://` URI; attempting to deploy with a local path fails fast with a clear error.
 
 ### 2. Add Build Entry for Jobs
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -158,6 +158,9 @@ interface RunnerEnvOptions {
 
   /** Secret names to load from GCP Secret Manager */
   secrets?: string[];
+
+  /** Destination for artifacts written via getExportsWriter() */
+  exportsPath?: string;
 }
 ```
 
@@ -195,6 +198,31 @@ Additional environment variables to set. These override any values loaded from `
 ### `secrets`
 
 An array of secret names to load from GCP Secret Manager. The secrets are loaded identically for both local and cloud execution — the execution environment is transparent.
+
+### `exportsPath`
+
+Destination for artifacts written via [`getExportsWriter()`](./exports). Accepts either a local path (resolved relative to the service directory) or a `gs://bucket[/prefix]` URI. Typically set per environment — a local directory for development, a bucket for cloud deployments.
+
+```typescript
+environments: {
+  local: defineRunnerEnv({
+    project: "my-project-dev",
+    exportsPath: "./exports",
+  }),
+  stag: defineRunnerEnv({
+    project: "my-project-stag",
+    exportsPath: "gs://my-project-stag-exports",
+  }),
+  prod: defineRunnerEnv({
+    project: "my-project-prod",
+    exportsPath: "gs://my-project-prod-exports",
+  }),
+},
+```
+
+Local paths are only honoured when running locally. Cloud deployments require a `gs://` URI — using a local path for `job cloud run/deploy` fails with a clear error so the misconfiguration can't be shipped.
+
+When `exportsPath` is unset, `getExportsWriter()` throws. See [Writing Exports](./exports) for the handler-side API.
 
 ## Environment Variable Precedence
 

--- a/docs/defining-jobs.md
+++ b/docs/defining-jobs.md
@@ -259,6 +259,25 @@ export default defineJob({
 });
 ```
 
+## Writing Exports
+
+Jobs that produce artifacts (reports, exports, generated files) can use `getExportsWriter()` to write JSON, CSV, or binary content to a destination configured per environment — a local directory during development, a Cloud Storage bucket in production.
+
+```typescript
+import { defineJob, getExportsWriter } from "gcp-job-runner";
+
+export default defineJob({
+  description: "Export pending comments",
+  handler: async () => {
+    const exports = getExportsWriter();
+    await exports.writeJson("pending-comments.json", rows);
+    await exports.writeText("pending-comments.csv", csvString);
+  },
+});
+```
+
+See [Writing Exports](./exports) for the full API and configuration details.
+
 ## Metadata and Discovery
 
 `defineJob()` attaches a `__metadata` property to the returned function containing the `description`. This is used by the job discovery system when listing available jobs.

--- a/docs/exports.md
+++ b/docs/exports.md
@@ -89,12 +89,12 @@ Absolute paths and upward traversal (`..`) are rejected so a job can't accidenta
 
 ## Local vs Cloud
 
-| Aspect            | Local (`./exports`)                              | Cloud (`gs://bucket/prefix`)                  |
-| ----------------- | ------------------------------------------------ | --------------------------------------------- |
-| Resolution        | Relative to the service directory (where `job-runner.config.ts` lives) | Parsed as a GCS URI, bucket + optional prefix |
-| Storage           | `node:fs` — directories created as needed        | `@google-cloud/storage`, uploaded with `.save()` |
-| Authentication    | None required                                    | Application Default Credentials (ADC)         |
-| Returned value    | Absolute filesystem path                         | Full `gs://` URI                              |
+| Aspect         | Local (`./exports`)                                                    | Cloud (`gs://bucket/prefix`)                     |
+| -------------- | ---------------------------------------------------------------------- | ------------------------------------------------ |
+| Resolution     | Relative to the service directory (where `job-runner.config.ts` lives) | Parsed as a GCS URI, bucket + optional prefix    |
+| Storage        | `node:fs` — directories created as needed                              | `@google-cloud/storage`, uploaded with `.save()` |
+| Authentication | None required                                                          | Application Default Credentials (ADC)            |
+| Returned value | Absolute filesystem path                                               | Full `gs://` URI                                 |
 
 The `@google-cloud/storage` module is lazy-loaded — jobs that only ever write to local paths don't pay the startup cost.
 

--- a/docs/exports.md
+++ b/docs/exports.md
@@ -1,0 +1,113 @@
+# Writing Exports
+
+Jobs frequently need to produce artifacts — JSON reports, CSV exports, generated assets — that you want to inspect later. `getExportsWriter()` gives you a single API that writes to a local directory when running on your machine and to a Cloud Storage bucket when running in the cloud.
+
+## Basic Usage
+
+```typescript
+import { defineJob, getExportsWriter } from "gcp-job-runner";
+
+export default defineJob({
+  description: "Export pending comments as JSON and CSV",
+  handler: async () => {
+    const exports = getExportsWriter();
+
+    await exports.writeJson("pending-comments.json", rows);
+    await exports.writeText("pending-comments.csv", csvString);
+  },
+});
+```
+
+The writer reads its destination from the `exportsPath` you set in your [runner config](./configuration#exportspath). Each environment can point at a different destination — typically a local path for development and a `gs://` URI for staging and production.
+
+```typescript
+environments: {
+  local: defineRunnerEnv({
+    project: "my-project-dev",
+    exportsPath: "./exports",
+  }),
+  stag: defineRunnerEnv({
+    project: "my-project-stag",
+    exportsPath: "gs://my-project-stag-exports",
+  }),
+},
+```
+
+## API
+
+```typescript
+interface ExportsWriter {
+  writeJson(relativePath: string, data: unknown): Promise<string>;
+  writeText(relativePath: string, content: string): Promise<string>;
+  writeBuffer(
+    relativePath: string,
+    content: Buffer | Uint8Array,
+  ): Promise<string>;
+}
+
+function getExportsWriter(): ExportsWriter;
+```
+
+Each method returns the resolved destination — an absolute path for local writes or the full `gs://` URI for cloud writes — and logs the same value so you can grab it from the job output.
+
+### `writeJson(relativePath, data)`
+
+Serializes `data` as pretty-printed JSON (2-space indent, trailing newline). Adds `.json` to `relativePath` if it isn't already present.
+
+```typescript
+await exports.writeJson("daily-stats", { users: 1234, orders: 56 });
+// → ./exports/daily-stats.json
+```
+
+### `writeText(relativePath, content)`
+
+Writes a UTF-8 string as-is. Use for CSV, SVG, Markdown, plain text — anything character-based. The content type sent to Cloud Storage is derived from the file extension.
+
+```typescript
+await exports.writeText(`unmatched-${today}.csv`, csv);
+```
+
+### `writeBuffer(relativePath, content)`
+
+Writes raw bytes. Use for binary formats like PNG, PDF, or protobuf. Uploads with `application/octet-stream`.
+
+```typescript
+await exports.writeBuffer("chart.png", pngBuffer);
+```
+
+## Nested Paths
+
+All methods accept paths with forward slashes. Parent directories are created automatically for local writes; for GCS the segments become part of the object key.
+
+```typescript
+await exports.writeJson(`db/airlines/${code}.json`, airline);
+// Local: ./exports/db/airlines/UA.json
+// Cloud: gs://my-bucket/db/airlines/UA.json
+```
+
+Absolute paths and upward traversal (`..`) are rejected so a job can't accidentally escape its configured destination.
+
+## Local vs Cloud
+
+| Aspect            | Local (`./exports`)                              | Cloud (`gs://bucket/prefix`)                  |
+| ----------------- | ------------------------------------------------ | --------------------------------------------- |
+| Resolution        | Relative to the service directory (where `job-runner.config.ts` lives) | Parsed as a GCS URI, bucket + optional prefix |
+| Storage           | `node:fs` — directories created as needed        | `@google-cloud/storage`, uploaded with `.save()` |
+| Authentication    | None required                                    | Application Default Credentials (ADC)         |
+| Returned value    | Absolute filesystem path                         | Full `gs://` URI                              |
+
+The `@google-cloud/storage` module is lazy-loaded — jobs that only ever write to local paths don't pay the startup cost.
+
+## Missing Configuration
+
+If a job calls `getExportsWriter()` without `exportsPath` set for the active environment, the call throws immediately with a message pointing at the config key. Choose the opt-in explicitly per environment rather than relying on implicit defaults.
+
+```
+Error: No exports destination configured.
+Set `exportsPath` on the current environment in your job-runner.config.ts,
+or set JOB_EXPORTS_PATH directly in the environment.
+```
+
+## Cloud Deployment Safety
+
+`exportsPath` values starting with `./` or `../` are rejected at cloud deploy/run time — local paths have no meaning inside a container, and silently writing to the container's filesystem would lose data when the task exits. Configure a `gs://` URI for every non-local environment.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -126,5 +126,6 @@ This discovers all compiled `.mjs` files in your jobs directory and lists them.
 - [Database Migration Example](./migration-example) — A real-world Firestore migration job
 - [Configuration](./configuration) — Full reference for `job-runner.config.ts`
 - [Defining Jobs](./defining-jobs) — Schema options, aliases, examples, and more
+- [Writing Exports](./exports) — Produce JSON, CSV, or binary artifacts from a job
 - [CLI Usage](./cli-usage) — All the ways to pass arguments
 - [Cloud Jobs](./cloud-jobs) — Deploy and run jobs in Cloud Run

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,6 +64,14 @@ features:
       </svg>
     title: Interactive Mode
     details: Browse and select jobs interactively. Argument prompts adapt to schema types — text inputs, selects for enums, confirmations for booleans.
+  - icon: |
+      <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+        <polyline points="7 10 12 15 17 10"/>
+        <line x1="12" x2="12" y1="15" y2="3"/>
+      </svg>
+    title: Unified Artifact Output
+    details: Write JSON, CSV, or binary artifacts with one API that targets a local directory during development and a Cloud Storage bucket in production. Same handler code.
 ---
 
 ## Quick Look

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -87,11 +87,13 @@ export default defineRunnerConfig({
       project: "my-project-stag",
       env: { LOG_LEVEL: "debug" },
       secrets: ["STRIPE_SECRET_KEY", "SENDGRID_API_KEY"],
+      exportsPath: "gs://my-project-stag-exports",
     }),
     prod: defineRunnerEnv({
       project: "my-project-prod",
       env: { LOG_LEVEL: "info" },
       secrets: ["STRIPE_SECRET_KEY", "SENDGRID_API_KEY"],
+      exportsPath: "gs://my-project-prod-exports",
     }),
   },
   cloud: {
@@ -99,6 +101,8 @@ export default defineRunnerConfig({
   },
 });
 ```
+
+`exportsPath` is optional and only needed if your jobs call [`getExportsWriter()`](./exports) to produce artifacts. For a local-only environment, use a relative path such as `"./exports"` instead of a bucket URI.
 
 ## Secrets
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@google-cloud/logging": "^11.2.0",
     "@google-cloud/secret-manager": "^6.1.1",
+    "@google-cloud/storage": "^7.19.0",
     "consola": "^3.4.0",
     "execa": "^9.6.1",
     "isolate-package": "1.28.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@google-cloud/secret-manager':
         specifier: ^6.1.1
         version: 6.1.1
+      '@google-cloud/storage':
+        specifier: ^7.19.0
+        version: 7.19.0(encoding@0.1.13)
       consola:
         specifier: ^3.4.0
         version: 3.4.2
@@ -532,6 +535,10 @@ packages:
     resolution: {integrity: sha512-dwSuxJ9RNmAW46FjK1StiNIeOiSHHQs/XIy4VArJ6bBMR+WsIvR+zhPh2pa40aFa9uTty67j38Rl268TVV62EA==}
     engines: {node: '>=18'}
 
+  '@google-cloud/storage@7.19.0':
+    resolution: {integrity: sha512-n2FjE7NAOYyshogdc7KQOl/VZb4sneqPjWouSyia9CMDdMhRX5+RIbqalNmC7LOLzuLAN89VlF2HvG8na9G+zQ==}
+    engines: {node: '>=14'}
+
   '@grpc/grpc-js@1.14.3':
     resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
     engines: {node: '>=12.10.0'}
@@ -581,6 +588,9 @@ packages:
 
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1640,6 +1650,9 @@ packages:
     resolution: {integrity: sha512-trmleAnZ2PxN/loHWVhhx1qeOHSRXq4TDsBBxq3GqeJitfk3+jTQ+v/C1km/KYq9M7wKqCewMh+/NAvVH7m+bw==}
     engines: {node: '>=20.19.0'}
 
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
+
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
@@ -2026,6 +2039,13 @@ packages:
 
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
+  fast-xml-builder@1.1.5:
+    resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
+
+  fast-xml-parser@5.7.1:
+    resolution: {integrity: sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==}
+    hasBin: true
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -2517,6 +2537,11 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
+  mime@3.0.0:
+    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -2713,6 +2738,10 @@ packages:
     resolution: {integrity: sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==}
     engines: {node: '>=4'}
 
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
   p-map@7.0.4:
     resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
     engines: {node: '>=18'}
@@ -2732,6 +2761,10 @@ packages:
   parse-ms@4.0.0:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
+
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
 
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -3115,6 +3148,9 @@ packages:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
 
+  strnum@2.2.3:
+    resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
+
   stubs@3.0.0:
     resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
 
@@ -3491,6 +3527,10 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
 
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
@@ -3894,6 +3934,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@google-cloud/storage@7.19.0(encoding@0.1.13)':
+    dependencies:
+      '@google-cloud/paginator': 5.0.2
+      '@google-cloud/projectify': 4.0.0
+      '@google-cloud/promisify': 4.0.0
+      abort-controller: 3.0.0
+      async-retry: 1.3.3
+      duplexify: 4.1.3
+      fast-xml-parser: 5.7.1
+      gaxios: 6.7.1(encoding@0.1.13)
+      google-auth-library: 9.15.1(encoding@0.1.13)
+      html-entities: 2.6.0
+      mime: 3.0.0
+      p-limit: 3.1.0
+      retry-request: 7.0.2(encoding@0.1.13)
+      teeny-request: 9.0.0(encoding@0.1.13)
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   '@grpc/grpc-js@1.14.3':
     dependencies:
       '@grpc/proto-loader': 0.8.0
@@ -3956,6 +4017,8 @@ snapshots:
       '@emnapi/runtime': 1.8.1
       '@tybys/wasm-util': 0.10.1
     optional: true
+
+  '@nodable/entities@2.1.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -4976,6 +5039,10 @@ snapshots:
       estree-walker: 3.0.3
       pathe: 2.0.3
 
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
+
   asynckit@0.4.0: {}
 
   b4a@1.8.0: {}
@@ -5382,6 +5449,17 @@ snapshots:
       micromatch: 4.0.8
 
   fast-safe-stringify@2.1.1: {}
+
+  fast-xml-builder@1.1.5:
+    dependencies:
+      path-expression-matcher: 1.5.0
+
+  fast-xml-parser@5.7.1:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.1.5
+      path-expression-matcher: 1.5.0
+      strnum: 2.2.3
 
   fastq@1.20.1:
     dependencies:
@@ -5975,6 +6053,8 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  mime@3.0.0: {}
+
   mimic-fn@2.1.0: {}
 
   mimic-fn@3.1.0: {}
@@ -6203,6 +6283,10 @@ snapshots:
 
   p-defer@1.0.0: {}
 
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
   p-map@7.0.4: {}
 
   package-json-from-dist@1.0.1: {}
@@ -6236,6 +6320,8 @@ snapshots:
       just-diff-apply: 5.5.0
 
   parse-ms@4.0.0: {}
+
+  path-expression-matcher@1.5.0: {}
 
   path-is-absolute@1.0.1: {}
 
@@ -6653,6 +6739,8 @@ snapshots:
 
   strip-json-comments@5.0.3: {}
 
+  strnum@2.2.3: {}
+
   stubs@3.0.0: {}
 
   superjson@2.2.6:
@@ -7045,6 +7133,8 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yocto-queue@0.1.0: {}
 
   yoctocolors@2.1.2: {}
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -315,6 +315,17 @@ async function handleLocalRun(options: LocalRunOptions): Promise<void> {
   /** Project always takes highest precedence */
   process.env.GOOGLE_CLOUD_PROJECT = envConfig.project;
 
+  /**
+   * Resolve local exportsPath values against the service directory so jobs
+   * can use consistent relative config (e.g. "./exports") from any cwd.
+   * `gs://` URIs pass through unchanged.
+   */
+  if (envConfig.exportsPath) {
+    process.env.JOB_EXPORTS_PATH = envConfig.exportsPath.startsWith("gs://")
+      ? envConfig.exportsPath
+      : path.resolve(process.cwd(), envConfig.exportsPath);
+  }
+
   if (envConfig.secrets && envConfig.secrets.length > 0) {
     const secrets = await getSecrets(envConfig.secrets);
     for (const [key, value] of Object.entries(secrets)) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -396,6 +396,8 @@ async function handleCloudDeploy(options: CloudDeployOptions): Promise<void> {
     process.exit(1);
   }
 
+  assertCloudExportsPath(envConfig);
+
   const serviceDirectory = process.cwd();
 
   const { imageUri } = await prepareImage({
@@ -406,6 +408,22 @@ async function handleCloudDeploy(options: CloudDeployOptions): Promise<void> {
 
   consola.info(`Image: ${imageUri}`);
   consola.success("Deploy complete");
+}
+
+/**
+ * Reject local exportsPath values for cloud commands — they would silently
+ * write to a container filesystem that is discarded on task exit.
+ */
+function assertCloudExportsPath(
+  envConfig: RunnerConfig["environments"][string],
+): void {
+  if (envConfig.exportsPath && !envConfig.exportsPath.startsWith("gs://")) {
+    consola.error(
+      `exportsPath "${envConfig.exportsPath}" is a local path but this is a cloud command.\n` +
+        "Use a gs:// URI for cloud environments (e.g. gs://my-bucket/exports).",
+    );
+    process.exit(1);
+  }
 }
 
 interface CloudRunOptions {
@@ -442,6 +460,8 @@ async function handleCloudRun(options: CloudRunOptions): Promise<void> {
     );
     process.exit(1);
   }
+
+  assertCloudExportsPath(envConfig);
 
   /** Override parallelism from CLI flag */
   if (parallelism !== undefined) {

--- a/src/cloud/deploy.ts
+++ b/src/cloud/deploy.ts
@@ -369,19 +369,10 @@ export async function createOrUpdateJob(
   };
 
   /**
-   * Forward the exports destination to the container. Only `gs://` URIs make
-   * sense in the cloud — local paths are rejected to surface config mistakes
-   * early rather than failing silently inside a container with no visible
-   * output location.
+   * Forward the exports destination to the container. Local paths are
+   * rejected earlier by assertCloudExportsPath() in the CLI handlers.
    */
   if (envConfig.exportsPath) {
-    if (!envConfig.exportsPath.startsWith("gs://")) {
-      consola.error(
-        `exportsPath "${envConfig.exportsPath}" is a local path but this is a cloud deployment.\n` +
-          "Use a gs:// URI for cloud environments (e.g. gs://my-bucket/exports).",
-      );
-      process.exit(1);
-    }
     envVars.JOB_EXPORTS_PATH = envConfig.exportsPath;
   }
 

--- a/src/cloud/deploy.ts
+++ b/src/cloud/deploy.ts
@@ -368,6 +368,23 @@ export async function createOrUpdateJob(
     GOOGLE_CLOUD_PROJECT: project,
   };
 
+  /**
+   * Forward the exports destination to the container. Only `gs://` URIs make
+   * sense in the cloud — local paths are rejected to surface config mistakes
+   * early rather than failing silently inside a container with no visible
+   * output location.
+   */
+  if (envConfig.exportsPath) {
+    if (!envConfig.exportsPath.startsWith("gs://")) {
+      consola.error(
+        `exportsPath "${envConfig.exportsPath}" is a local path but this is a cloud deployment.\n` +
+          "Use a gs:// URI for cloud environments (e.g. gs://my-bucket/exports).",
+      );
+      process.exit(1);
+    }
+    envVars.JOB_EXPORTS_PATH = envConfig.exportsPath;
+  }
+
   const envVarsString = Object.entries(envVars)
     .map(([key, value]) => `${key}=${value}`)
     .join(",");

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,17 @@ export interface RunnerEnvOptions {
   env?: Record<string, string>;
   /** Secret names to load from GCP Secret Manager */
   secrets?: string[];
+  /**
+   * Destination for artifacts written via `getExportsWriter()`.
+   *
+   * Either a local path (resolved relative to the service directory) or a
+   * `gs://bucket[/prefix]` URI. Typically set per environment — e.g. a local
+   * directory for development and a bucket for cloud deployments.
+   *
+   * When unset, `getExportsWriter()` throws. Local paths are only applied when
+   * running locally; cloud deployments require a `gs://` URI.
+   */
+  exportsPath?: string;
 }
 
 /** Container resource limits for a Cloud Run Job */

--- a/src/exports.integration.test.ts
+++ b/src/exports.integration.test.ts
@@ -1,0 +1,76 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { defineJob } from "./define-job";
+import { getExportsWriter } from "./exports";
+
+/**
+ * Exercises the full public-API path a job author would use: `defineJob`
+ * composes the handler, the runner sets `JOB_EXPORTS_PATH` (simulated here),
+ * and the handler writes files via `getExportsWriter`. Catches regressions
+ * where the two pieces are individually correct but don't compose.
+ */
+describe("exports integration", () => {
+  let tempDir: string;
+  const originalExportsPath = process.env.JOB_EXPORTS_PATH;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "exports-integration-"));
+    process.env.JOB_EXPORTS_PATH = tempDir;
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    if (originalExportsPath === undefined) {
+      delete process.env.JOB_EXPORTS_PATH;
+    } else {
+      process.env.JOB_EXPORTS_PATH = originalExportsPath;
+    }
+  });
+
+  it("writes artifacts from inside a defineJob handler", async () => {
+    const job = defineJob({
+      handler: async () => {
+        const exports = getExportsWriter();
+        await exports.writeJson("report.json", { count: 42 });
+        await exports.writeText("report.csv", "id,count\n1,42\n");
+      },
+    });
+
+    await job([], "report");
+
+    expect(readFileSync(path.join(tempDir, "report.json"), "utf-8")).toBe(
+      '{\n  "count": 42\n}\n',
+    );
+    expect(readFileSync(path.join(tempDir, "report.csv"), "utf-8")).toBe(
+      "id,count\n1,42\n",
+    );
+  });
+
+  it("surfaces config errors to the handler caller", async () => {
+    delete process.env.JOB_EXPORTS_PATH;
+
+    const job = defineJob({
+      handler: async () => {
+        getExportsWriter();
+      },
+    });
+
+    await expect(job([], "missing-config")).rejects.toThrow(/exportsPath/);
+  });
+
+  it("writes to nested directories declared in the relative path", async () => {
+    const job = defineJob({
+      handler: async () => {
+        const exports = getExportsWriter();
+        await exports.writeJson("db/airlines/UA.json", { iata: "UA" });
+      },
+    });
+
+    await job([], "nested");
+
+    const fullPath = path.join(tempDir, "db", "airlines", "UA.json");
+    expect(readFileSync(fullPath, "utf-8")).toContain('"iata": "UA"');
+  });
+});

--- a/src/exports.test.ts
+++ b/src/exports.test.ts
@@ -1,0 +1,226 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { consola } from "consola";
+import { getExportsWriter } from "./exports";
+
+describe("getExportsWriter", () => {
+  let tempDir: string;
+  const originalExportsPath = process.env.JOB_EXPORTS_PATH;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "exports-test-"));
+    process.env.JOB_EXPORTS_PATH = tempDir;
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    if (originalExportsPath === undefined) {
+      delete process.env.JOB_EXPORTS_PATH;
+    } else {
+      process.env.JOB_EXPORTS_PATH = originalExportsPath;
+    }
+    vi.restoreAllMocks();
+  });
+
+  describe("configuration", () => {
+    it("throws when JOB_EXPORTS_PATH is unset", () => {
+      delete process.env.JOB_EXPORTS_PATH;
+      expect(() => getExportsWriter()).toThrowError(/exportsPath/);
+    });
+
+    it("throws when JOB_EXPORTS_PATH is empty", () => {
+      process.env.JOB_EXPORTS_PATH = "";
+      expect(() => getExportsWriter()).toThrowError(/exportsPath/);
+    });
+  });
+
+  describe("local writer", () => {
+    it("writes pretty-printed JSON with trailing newline", async () => {
+      const writer = getExportsWriter();
+      const fullPath = await writer.writeJson("data.json", {
+        a: 1,
+        b: [2, 3],
+      });
+
+      expect(fullPath).toBe(path.join(tempDir, "data.json"));
+      expect(readFileSync(fullPath, "utf-8")).toBe(
+        '{\n  "a": 1,\n  "b": [\n    2,\n    3\n  ]\n}\n',
+      );
+    });
+
+    it("adds .json extension when missing", async () => {
+      const writer = getExportsWriter();
+      const fullPath = await writer.writeJson("report", { ok: true });
+
+      expect(fullPath).toBe(path.join(tempDir, "report.json"));
+      expect(readFileSync(fullPath, "utf-8")).toBe('{\n  "ok": true\n}\n');
+    });
+
+    it("does not double-add .json extension", async () => {
+      const writer = getExportsWriter();
+      const fullPath = await writer.writeJson("report.json", { ok: true });
+      expect(fullPath).toBe(path.join(tempDir, "report.json"));
+    });
+
+    it("writes text content unchanged", async () => {
+      const writer = getExportsWriter();
+      const csv = "id,name\n1,Alice\n2,Bob\n";
+      const fullPath = await writer.writeText("users.csv", csv);
+
+      expect(fullPath).toBe(path.join(tempDir, "users.csv"));
+      expect(readFileSync(fullPath, "utf-8")).toBe(csv);
+    });
+
+    it("writes binary buffers unchanged", async () => {
+      const writer = getExportsWriter();
+      const buffer = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+      const fullPath = await writer.writeBuffer("icon.png", buffer);
+
+      expect(fullPath).toBe(path.join(tempDir, "icon.png"));
+      const written = readFileSync(fullPath);
+      expect(written.equals(buffer)).toBe(true);
+    });
+
+    it("creates nested directories as needed", async () => {
+      const writer = getExportsWriter();
+      const fullPath = await writer.writeJson("db/airlines/UA.json", {
+        code: "UA",
+      });
+
+      expect(fullPath).toBe(path.join(tempDir, "db", "airlines", "UA.json"));
+      expect(readFileSync(fullPath, "utf-8")).toContain('"code": "UA"');
+    });
+
+    it("logs the written path", async () => {
+      const infoSpy = vi.spyOn(consola, "info").mockImplementation(() => {});
+      const writer = getExportsWriter();
+      await writer.writeText("a.txt", "hi");
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining(path.join(tempDir, "a.txt")),
+      );
+    });
+
+    it("rejects absolute paths", async () => {
+      const writer = getExportsWriter();
+      await expect(writer.writeText("/etc/passwd", "pwned")).rejects.toThrow(
+        /Absolute paths are not allowed/,
+      );
+    });
+
+    it("rejects parent-directory traversal", async () => {
+      const writer = getExportsWriter();
+      await expect(writer.writeText("../escape.txt", "pwned")).rejects.toThrow(
+        /must not traverse upward/,
+      );
+      await expect(
+        writer.writeText("a/../../escape.txt", "pwned"),
+      ).rejects.toThrow(/must not traverse upward/);
+    });
+
+    it("rejects empty paths", async () => {
+      const writer = getExportsWriter();
+      await expect(writer.writeText("", "x")).rejects.toThrow(/empty/);
+    });
+
+    it("resolves relative base path to absolute", async () => {
+      process.env.JOB_EXPORTS_PATH = tempDir;
+      const writer = getExportsWriter();
+      const fullPath = await writer.writeText("x.txt", "y");
+      expect(path.isAbsolute(fullPath)).toBe(true);
+    });
+  });
+
+  describe("gcs writer", () => {
+    const saveMock = vi.fn().mockResolvedValue(undefined);
+    const fileMock = vi.fn(() => ({ save: saveMock }));
+    const bucketMock = vi.fn(() => ({ file: fileMock }));
+
+    beforeEach(() => {
+      saveMock.mockClear();
+      fileMock.mockClear();
+      bucketMock.mockClear();
+      vi.doMock("@google-cloud/storage", () => ({
+        Storage: class {
+          bucket = bucketMock;
+        },
+      }));
+    });
+
+    afterEach(() => {
+      vi.doUnmock("@google-cloud/storage");
+      vi.resetModules();
+    });
+
+    it("routes to the configured bucket and prefix for JSON", async () => {
+      process.env.JOB_EXPORTS_PATH = "gs://my-bucket/jobs";
+      vi.resetModules();
+      const { getExportsWriter: freshWriter } = await import("./exports");
+      const writer = freshWriter();
+
+      const uri = await writer.writeJson("data/flights.json", { count: 5 });
+
+      expect(uri).toBe("gs://my-bucket/jobs/data/flights.json");
+      expect(bucketMock).toHaveBeenCalledWith("my-bucket");
+      expect(fileMock).toHaveBeenCalledWith("jobs/data/flights.json");
+      expect(saveMock).toHaveBeenCalledWith(
+        '{\n  "count": 5\n}\n',
+        expect.objectContaining({
+          contentType: "application/json",
+          resumable: false,
+        }),
+      );
+    });
+
+    it("handles bucket-only URIs (no prefix)", async () => {
+      process.env.JOB_EXPORTS_PATH = "gs://my-bucket";
+      vi.resetModules();
+      const { getExportsWriter: freshWriter } = await import("./exports");
+      const writer = freshWriter();
+
+      const uri = await writer.writeText("report.csv", "a,b\n1,2\n");
+
+      expect(uri).toBe("gs://my-bucket/report.csv");
+      expect(fileMock).toHaveBeenCalledWith("report.csv");
+      expect(saveMock).toHaveBeenCalledWith(
+        "a,b\n1,2\n",
+        expect.objectContaining({ contentType: "text/csv; charset=utf-8" }),
+      );
+    });
+
+    it("passes buffers through as binary", async () => {
+      process.env.JOB_EXPORTS_PATH = "gs://my-bucket/artifacts";
+      vi.resetModules();
+      const { getExportsWriter: freshWriter } = await import("./exports");
+      const writer = freshWriter();
+
+      const buffer = Buffer.from([1, 2, 3]);
+      const uri = await writer.writeBuffer("blob.bin", buffer);
+
+      expect(uri).toBe("gs://my-bucket/artifacts/blob.bin");
+      expect(saveMock).toHaveBeenCalledWith(
+        buffer,
+        expect.objectContaining({ contentType: "application/octet-stream" }),
+      );
+    });
+
+    it("throws on invalid URI without bucket", async () => {
+      process.env.JOB_EXPORTS_PATH = "gs://";
+      vi.resetModules();
+      const { getExportsWriter: freshWriter } = await import("./exports");
+      expect(() => freshWriter()).toThrowError(/missing bucket name/);
+    });
+
+    it("rejects traversal in GCS paths too", async () => {
+      process.env.JOB_EXPORTS_PATH = "gs://my-bucket/jobs";
+      vi.resetModules();
+      const { getExportsWriter: freshWriter } = await import("./exports");
+      const writer = freshWriter();
+
+      await expect(writer.writeText("../secret.txt", "no")).rejects.toThrow(
+        /must not traverse upward/,
+      );
+    });
+  });
+});

--- a/src/exports.test.ts
+++ b/src/exports.test.ts
@@ -132,6 +132,10 @@ describe("getExportsWriter", () => {
     it("rejects empty paths", async () => {
       const writer = getExportsWriter();
       await expect(writer.writeText("", "x")).rejects.toThrow(/empty/);
+      await expect(writer.writeBuffer("", Buffer.from("x"))).rejects.toThrow(
+        /empty/,
+      );
+      await expect(writer.writeJson("", { ok: true })).rejects.toThrow(/empty/);
     });
 
     it("resolves relative base path to absolute", async () => {

--- a/src/exports.test.ts
+++ b/src/exports.test.ts
@@ -117,6 +117,16 @@ describe("getExportsWriter", () => {
       await expect(
         writer.writeText("a/../../escape.txt", "pwned"),
       ).rejects.toThrow(/must not traverse upward/);
+      await expect(writer.writeText("..", "pwned")).rejects.toThrow(
+        /must not traverse upward/,
+      );
+    });
+
+    it("allows filenames that start with two dots", async () => {
+      const writer = getExportsWriter();
+      const fullPath = await writer.writeText("..hidden", "ok");
+      expect(fullPath).toBe(path.join(tempDir, "..hidden"));
+      expect(readFileSync(fullPath, "utf-8")).toBe("ok");
     });
 
     it("rejects empty paths", async () => {

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -54,11 +54,11 @@ export function getExportsWriter(): ExportsWriter {
 function createLocalWriter(basePath: string): ExportsWriter {
   const resolvedBase = path.resolve(basePath);
 
+  /** Takes an already-sanitized relative path and writes the content. */
   async function write(
-    relativePath: string,
+    safeRelative: string,
     content: string | Uint8Array,
   ): Promise<string> {
-    const safeRelative = sanitizeRelativePath(relativePath);
     const fullPath = path.join(resolvedBase, safeRelative);
 
     await mkdir(path.dirname(fullPath), { recursive: true });
@@ -77,11 +77,11 @@ function createLocalWriter(basePath: string): ExportsWriter {
       );
       return write(withExtension, formatJson(data));
     },
-    writeText(relativePath, content) {
-      return write(relativePath, content);
+    async writeText(relativePath, content) {
+      return write(sanitizeRelativePath(relativePath), content);
     },
-    writeBuffer(relativePath, content) {
-      return write(relativePath, content);
+    async writeBuffer(relativePath, content) {
+      return write(sanitizeRelativePath(relativePath), content);
     },
   };
 }
@@ -94,12 +94,12 @@ interface GcsTarget {
 function createGcsWriter(uri: string): ExportsWriter {
   const target = parseGcsUri(uri);
 
+  /** Takes an already-sanitized relative path and uploads the content. */
   async function write(
-    relativePath: string,
+    safeRelative: string,
     content: string | Buffer | Uint8Array,
     contentType: string,
   ): Promise<string> {
-    const safeRelative = sanitizeRelativePath(relativePath);
     const objectName = joinGcsPath(target.prefix, safeRelative);
     const fullUri = `${GCS_PREFIX}${target.bucket}/${objectName}`;
 
@@ -129,11 +129,19 @@ function createGcsWriter(uri: string): ExportsWriter {
       );
       return write(withExtension, formatJson(data), "application/json");
     },
-    writeText(relativePath, content) {
-      return write(relativePath, content, contentTypeFor(relativePath));
+    async writeText(relativePath, content) {
+      return write(
+        sanitizeRelativePath(relativePath),
+        content,
+        contentTypeFor(relativePath),
+      );
     },
-    writeBuffer(relativePath, content) {
-      return write(relativePath, content, "application/octet-stream");
+    async writeBuffer(relativePath, content) {
+      return write(
+        sanitizeRelativePath(relativePath),
+        content,
+        "application/octet-stream",
+      );
     },
   };
 }

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -1,0 +1,219 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { consola } from "consola";
+import type { Storage } from "@google-cloud/storage";
+
+/**
+ * Writer for job artifacts, produced by `getExportsWriter()`. A single writer
+ * instance targets a destination configured via the `exportsPath` runner
+ * option (local directory or `gs://` URI). All methods return the resolved
+ * absolute path or `gs://` URI of the written artifact.
+ */
+export interface ExportsWriter {
+  /**
+   * Write a value as pretty-printed JSON (2-space indent, trailing newline).
+   * The `.json` extension is added if missing.
+   */
+  writeJson(relativePath: string, data: unknown): Promise<string>;
+  /** Write a UTF-8 string (e.g. CSV, SVG, plain text). */
+  writeText(relativePath: string, content: string): Promise<string>;
+  /** Write a binary buffer. */
+  writeBuffer(
+    relativePath: string,
+    content: Buffer | Uint8Array,
+  ): Promise<string>;
+}
+
+const GCS_PREFIX = "gs://";
+
+/**
+ * Return a writer that persists artifacts to the destination configured via
+ * the `exportsPath` runner option. Local paths are used for local execution;
+ * `gs://bucket[/prefix]` URIs are used for Cloud Run deployments.
+ *
+ * Throws when no destination is configured.
+ */
+export function getExportsWriter(): ExportsWriter {
+  const destination = process.env.JOB_EXPORTS_PATH;
+
+  if (!destination) {
+    throw new Error(
+      "No exports destination configured.\n" +
+        "Set `exportsPath` on the current environment in your job-runner.config.ts, " +
+        "or set JOB_EXPORTS_PATH directly in the environment.",
+    );
+  }
+
+  if (destination.startsWith(GCS_PREFIX)) {
+    return createGcsWriter(destination);
+  }
+
+  return createLocalWriter(destination);
+}
+
+function createLocalWriter(basePath: string): ExportsWriter {
+  const resolvedBase = path.resolve(basePath);
+
+  async function write(
+    relativePath: string,
+    content: string | Uint8Array,
+  ): Promise<string> {
+    const safeRelative = sanitizeRelativePath(relativePath);
+    const fullPath = path.join(resolvedBase, safeRelative);
+
+    await mkdir(path.dirname(fullPath), { recursive: true });
+    await writeFile(fullPath, content);
+
+    consola.info(`Export written: ${fullPath}`);
+    return fullPath;
+  }
+
+  return {
+    writeJson(relativePath, data) {
+      const withExtension = ensureExtension(relativePath, ".json");
+      return write(withExtension, formatJson(data));
+    },
+    writeText(relativePath, content) {
+      return write(relativePath, content);
+    },
+    writeBuffer(relativePath, content) {
+      return write(relativePath, content);
+    },
+  };
+}
+
+interface GcsTarget {
+  bucket: string;
+  prefix: string;
+}
+
+function createGcsWriter(uri: string): ExportsWriter {
+  const target = parseGcsUri(uri);
+
+  async function write(
+    relativePath: string,
+    content: string | Buffer | Uint8Array,
+    contentType: string,
+  ): Promise<string> {
+    const safeRelative = sanitizeRelativePath(relativePath);
+    const objectName = joinGcsPath(target.prefix, safeRelative);
+    const fullUri = `${GCS_PREFIX}${target.bucket}/${objectName}`;
+
+    const storage = await getStorageClient();
+    const file = storage.bucket(target.bucket).file(objectName);
+
+    const body =
+      typeof content === "string" || Buffer.isBuffer(content)
+        ? content
+        : Buffer.from(content);
+
+    await file.save(body, {
+      contentType,
+      resumable: false,
+    });
+
+    consola.info(`Export written: ${fullUri}`);
+    return fullUri;
+  }
+
+  return {
+    writeJson(relativePath, data) {
+      const withExtension = ensureExtension(relativePath, ".json");
+      return write(withExtension, formatJson(data), "application/json");
+    },
+    writeText(relativePath, content) {
+      return write(relativePath, content, contentTypeFor(relativePath));
+    },
+    writeBuffer(relativePath, content) {
+      return write(relativePath, content, "application/octet-stream");
+    },
+  };
+}
+
+/**
+ * Lazy Storage client singleton. The `@google-cloud/storage` module is only
+ * loaded when a `gs://` destination is actually used for a write.
+ */
+let storageClient: Storage | null = null;
+async function getStorageClient(): Promise<Storage> {
+  if (storageClient) return storageClient;
+  const { Storage: StorageCtor } = await import("@google-cloud/storage");
+  storageClient = new StorageCtor();
+  return storageClient;
+}
+
+function parseGcsUri(uri: string): GcsTarget {
+  const withoutScheme = uri.slice(GCS_PREFIX.length);
+  const slashIndex = withoutScheme.indexOf("/");
+
+  if (slashIndex === -1) {
+    if (!withoutScheme) {
+      throw new Error(`Invalid GCS URI: "${uri}" (missing bucket name)`);
+    }
+    return { bucket: withoutScheme, prefix: "" };
+  }
+
+  const bucket = withoutScheme.slice(0, slashIndex);
+  const prefix = withoutScheme.slice(slashIndex + 1).replace(/\/+$/, "");
+
+  if (!bucket) {
+    throw new Error(`Invalid GCS URI: "${uri}" (missing bucket name)`);
+  }
+
+  return { bucket, prefix };
+}
+
+function joinGcsPath(prefix: string, relative: string): string {
+  const normalizedRelative = relative.replace(/^\/+/, "");
+  return prefix ? `${prefix}/${normalizedRelative}` : normalizedRelative;
+}
+
+function sanitizeRelativePath(relativePath: string): string {
+  if (!relativePath || relativePath.trim() === "") {
+    throw new Error("Export path is empty");
+  }
+
+  if (path.isAbsolute(relativePath) || relativePath.startsWith("/")) {
+    throw new Error(
+      `Export path must be relative, got "${relativePath}". ` +
+        "Absolute paths are not allowed.",
+    );
+  }
+
+  const normalized = path.posix.normalize(relativePath.replace(/\\/g, "/"));
+
+  if (normalized.startsWith("..") || normalized.split("/").includes("..")) {
+    throw new Error(
+      `Export path must not traverse upward, got "${relativePath}".`,
+    );
+  }
+
+  return normalized;
+}
+
+function ensureExtension(relativePath: string, extension: string): string {
+  return relativePath.endsWith(extension)
+    ? relativePath
+    : `${relativePath}${extension}`;
+}
+
+function formatJson(data: unknown): string {
+  return `${JSON.stringify(data, null, 2)}\n`;
+}
+
+const TEXT_CONTENT_TYPES: Record<string, string> = {
+  ".csv": "text/csv; charset=utf-8",
+  ".json": "application/json",
+  ".svg": "image/svg+xml",
+  ".txt": "text/plain; charset=utf-8",
+  ".html": "text/html; charset=utf-8",
+  ".xml": "application/xml",
+  ".yaml": "application/yaml",
+  ".yml": "application/yaml",
+  ".md": "text/markdown; charset=utf-8",
+};
+
+function contentTypeFor(relativePath: string): string {
+  const ext = path.posix.extname(relativePath).toLowerCase();
+  return TEXT_CONTENT_TYPES[ext] ?? "text/plain; charset=utf-8";
+}

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -130,11 +130,8 @@ function createGcsWriter(uri: string): ExportsWriter {
       return write(withExtension, formatJson(data), "application/json");
     },
     async writeText(relativePath, content) {
-      return write(
-        sanitizeRelativePath(relativePath),
-        content,
-        contentTypeFor(relativePath),
-      );
+      const safe = sanitizeRelativePath(relativePath);
+      return write(safe, content, contentTypeFor(safe));
     },
     async writeBuffer(relativePath, content) {
       return write(

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -182,7 +182,12 @@ function sanitizeRelativePath(relativePath: string): string {
 
   const normalized = path.posix.normalize(relativePath.replace(/\\/g, "/"));
 
-  if (normalized.startsWith("..") || normalized.split("/").includes("..")) {
+  /**
+   * Reject `..` only as a distinct path segment, not as a prefix. A filename
+   * like "..hidden" is a legitimate dotfile variant, while ".." / "../x" /
+   * "a/../../x" all produce a `..` segment after normalization.
+   */
+  if (normalized.split("/").includes("..")) {
     throw new Error(
       `Export path must not traverse upward, got "${relativePath}".`,
     );

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -69,8 +69,12 @@ function createLocalWriter(basePath: string): ExportsWriter {
   }
 
   return {
-    writeJson(relativePath, data) {
-      const withExtension = ensureExtension(relativePath, ".json");
+    async writeJson(relativePath, data) {
+      /** Sanitize before appending the extension so "" doesn't become ".json". */
+      const withExtension = ensureExtension(
+        sanitizeRelativePath(relativePath),
+        ".json",
+      );
       return write(withExtension, formatJson(data));
     },
     writeText(relativePath, content) {
@@ -117,8 +121,12 @@ function createGcsWriter(uri: string): ExportsWriter {
   }
 
   return {
-    writeJson(relativePath, data) {
-      const withExtension = ensureExtension(relativePath, ".json");
+    async writeJson(relativePath, data) {
+      /** Sanitize before appending the extension so "" doesn't become ".json". */
+      const withExtension = ensureExtension(
+        sanitizeRelativePath(relativePath),
+        ".json",
+      );
       return write(withExtension, formatJson(data), "application/json");
     },
     writeText(relativePath, content) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 export { defineRunnerConfig, defineRunnerEnv } from "./config";
 export { defineJob } from "./define-job";
 export { discoverJobs } from "./discover-jobs";
+export { getExportsWriter } from "./exports";
+export type { ExportsWriter } from "./exports";
 export {
   extractFieldInfo,
   formatZodError,


### PR DESCRIPTION
Adds a `getExportsWriter()` utility and matching `exportsPath` option on `RunnerEnvOptions` so jobs can persist artifacts (JSON, CSV, binary) to a destination that varies per environment. Local paths resolve against the service directory; `gs://bucket[/prefix]` URIs route through `@google-cloud/storage`. The writer throws when `exportsPath` is unset, and cloud deployments fail fast if a local path is configured for a cloud environment (local paths would silently write to a container filesystem that is discarded on task exit).

The handler-side API is a small object with `writeJson`, `writeText`, and `writeBuffer` methods — covers JSON reports, CSV exports, SVG, PNG, and any other format. Each method returns and logs the resolved destination so the location is easy to find in job output. `@google-cloud/storage` is lazy-loaded so jobs that only ever write locally do not pay its import cost.

Scope: packages (gcp-job-runner)
Visibility: user-facing