### PR TITLE
Add localExportsPath for single local destination across envs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,6 +46,12 @@ interface RunnerConfig {
   /** Named environments (e.g., stag, prod) */
   environments: Record<string, RunnerEnvOptions>;
 
+  /**
+   * Destination used by getExportsWriter() for every local run, regardless
+   * of which environment is selected. Local path or gs:// URI.
+   */
+  localExportsPath?: string;
+
   /** Cloud Run Jobs configuration */
   cloud?: CloudConfig;
 
@@ -90,6 +96,35 @@ export default defineRunnerConfig({
 ```
 
 Build output is hidden to keep the terminal clean — you'll see a "Building..." indicator. If the build fails, the full output is displayed.
+
+### `localExportsPath`
+
+A destination used by [`getExportsWriter()`](./exports) for every local run, regardless of which environment is selected. Either a local path (resolved relative to the service directory) or a `gs://bucket[/prefix]` URI.
+
+```typescript
+export default defineRunnerConfig({
+  localExportsPath: "./exports",
+  environments: {
+    stag: defineRunnerEnv({
+      project: "my-project-stag",
+      exportsPath: "gs://my-project-stag-exports",
+    }),
+    prod: defineRunnerEnv({
+      project: "my-project-prod",
+      exportsPath: "gs://my-project-prod-exports",
+    }),
+  },
+});
+```
+
+When running jobs locally, the selected environment still controls which project's data you read or write — but the _destination_ for artifacts is usually the same developer machine. `localExportsPath` captures that: one top-level setting instead of per-env duplication.
+
+When `localExportsPath` is set:
+
+- Local runs (`job local run <env>`) use `localExportsPath` and ignore the environment's `exportsPath`.
+- Cloud runs (`job cloud run <env>` / `job cloud deploy <env>`) use the environment's `exportsPath` as before.
+
+When `localExportsPath` is unset, local runs fall back to the environment's `exportsPath` — existing configurations continue to work unchanged.
 
 ### `cloud`
 
@@ -201,28 +236,29 @@ An array of secret names to load from GCP Secret Manager. The secrets are loaded
 
 ### `exportsPath`
 
-Destination for artifacts written via [`getExportsWriter()`](./exports). Accepts either a local path (resolved relative to the service directory) or a `gs://bucket[/prefix]` URI. Typically set per environment — a local directory for development, a bucket for cloud deployments.
+Destination for artifacts written via [`getExportsWriter()`](./exports) for this environment. Accepts either a local path (resolved relative to the service directory) or a `gs://bucket[/prefix]` URI.
+
+For most setups this is a `gs://` URI per environment, paired with a top-level [`localExportsPath`](#localexportspath) that handles every local run:
 
 ```typescript
-environments: {
-  local: defineRunnerEnv({
-    project: "my-project-dev",
-    exportsPath: "./exports",
-  }),
-  stag: defineRunnerEnv({
-    project: "my-project-stag",
-    exportsPath: "gs://my-project-stag-exports",
-  }),
-  prod: defineRunnerEnv({
-    project: "my-project-prod",
-    exportsPath: "gs://my-project-prod-exports",
-  }),
-},
+export default defineRunnerConfig({
+  localExportsPath: "./exports",
+  environments: {
+    stag: defineRunnerEnv({
+      project: "my-project-stag",
+      exportsPath: "gs://my-project-stag-exports",
+    }),
+    prod: defineRunnerEnv({
+      project: "my-project-prod",
+      exportsPath: "gs://my-project-prod-exports",
+    }),
+  },
+});
 ```
 
-Local paths are only honoured when running locally. Cloud deployments require a `gs://` URI — using a local path for `job cloud run/deploy` fails with a clear error so the misconfiguration can't be shipped.
+Local paths on an environment's `exportsPath` are only honoured when `localExportsPath` is unset and the run is local. Cloud deployments always require a `gs://` URI — using a local path for `job cloud run/deploy` fails with a clear error so the misconfiguration can't be shipped.
 
-When `exportsPath` is unset, `getExportsWriter()` throws. See [Writing Exports](./exports) for the handler-side API.
+When neither `localExportsPath` nor `exportsPath` is set, `getExportsWriter()` throws. See [Writing Exports](./exports) for the handler-side API.
 
 ## Environment Variable Precedence
 

--- a/docs/exports.md
+++ b/docs/exports.md
@@ -21,6 +21,9 @@ export default defineJob({
 The writer reads its destination from your [runner config](./configuration). For most setups you'll pair a top-level [`localExportsPath`](./configuration#localexportspath) — used for every local run regardless of environment — with a per-environment [`exportsPath`](./configuration#exportspath) used for cloud execution:
 
 ```typescript
+// job-runner.config.ts
+import { defineRunnerConfig, defineRunnerEnv } from "gcp-job-runner";
+
 export default defineRunnerConfig({
   localExportsPath: "./exports",
   environments: {
@@ -109,8 +112,8 @@ If a job calls `getExportsWriter()` without a destination configured — neither
 
 ```
 Error: No exports destination configured.
-Set `exportsPath` on the current environment in your job-runner.config.ts,
-or set JOB_EXPORTS_PATH directly in the environment.
+Set `localExportsPath` or the current environment's `exportsPath` in your
+job-runner.config.ts, or set JOB_EXPORTS_PATH directly in the environment.
 ```
 
 ## Cloud Deployment Safety

--- a/docs/exports.md
+++ b/docs/exports.md
@@ -18,20 +18,25 @@ export default defineJob({
 });
 ```
 
-The writer reads its destination from the `exportsPath` you set in your [runner config](./configuration#exportspath). Each environment can point at a different destination — typically a local path for development and a `gs://` URI for staging and production.
+The writer reads its destination from your [runner config](./configuration). For most setups you'll pair a top-level [`localExportsPath`](./configuration#localexportspath) — used for every local run regardless of environment — with a per-environment [`exportsPath`](./configuration#exportspath) used for cloud execution:
 
 ```typescript
-environments: {
-  local: defineRunnerEnv({
-    project: "my-project-dev",
-    exportsPath: "./exports",
-  }),
-  stag: defineRunnerEnv({
-    project: "my-project-stag",
-    exportsPath: "gs://my-project-stag-exports",
-  }),
-},
+export default defineRunnerConfig({
+  localExportsPath: "./exports",
+  environments: {
+    stag: defineRunnerEnv({
+      project: "my-project-stag",
+      exportsPath: "gs://my-project-stag-exports",
+    }),
+    prod: defineRunnerEnv({
+      project: "my-project-prod",
+      exportsPath: "gs://my-project-prod-exports",
+    }),
+  },
+});
 ```
+
+`localExportsPath` is optional — if you prefer to configure a destination per environment, just set `exportsPath` on each env and leave `localExportsPath` unset.
 
 ## API
 
@@ -100,7 +105,7 @@ The `@google-cloud/storage` module is lazy-loaded — jobs that only ever write 
 
 ## Missing Configuration
 
-If a job calls `getExportsWriter()` without `exportsPath` set for the active environment, the call throws immediately with a message pointing at the config key. Choose the opt-in explicitly per environment rather than relying on implicit defaults.
+If a job calls `getExportsWriter()` without a destination configured — neither `localExportsPath` nor the active environment's `exportsPath` is set — the call throws immediately with a message pointing at the config key. Choose the opt-in explicitly rather than relying on implicit defaults.
 
 ```
 Error: No exports destination configured.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import process from "node:process";
 import { consola } from "consola";
 import type { ZodObject, ZodRawShape } from "zod";
-import type { RunnerConfig } from "./config";
+import { resolveLocalExportsPath, type RunnerConfig } from "./config";
 import {
   createOrUpdateJob,
   deployIfChanged,
@@ -316,14 +316,17 @@ async function handleLocalRun(options: LocalRunOptions): Promise<void> {
   process.env.GOOGLE_CLOUD_PROJECT = envConfig.project;
 
   /**
-   * Resolve local exportsPath values against the service directory so jobs
-   * can use consistent relative config (e.g. "./exports") from any cwd.
-   * `gs://` URIs pass through unchanged.
+   * `localExportsPath` wins over the environment's `exportsPath` for local
+   * runs so developers can use one destination regardless of whether they
+   * point at stag or prod data.
    */
-  if (envConfig.exportsPath) {
-    process.env.JOB_EXPORTS_PATH = envConfig.exportsPath.startsWith("gs://")
-      ? envConfig.exportsPath
-      : path.resolve(process.cwd(), envConfig.exportsPath);
+  const localExportsPath = resolveLocalExportsPath(
+    config,
+    envConfig,
+    process.cwd(),
+  );
+  if (localExportsPath !== undefined) {
+    process.env.JOB_EXPORTS_PATH = localExportsPath;
   }
 
   if (envConfig.secrets && envConfig.secrets.length > 0) {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,66 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveLocalExportsPath } from "./config";
+
+const SERVICE_DIR = "/srv/my-service";
+
+describe("resolveLocalExportsPath", () => {
+  it("returns undefined when neither localExportsPath nor exportsPath is set", () => {
+    expect(resolveLocalExportsPath({}, {}, SERVICE_DIR)).toBeUndefined();
+  });
+
+  it("prefers localExportsPath over env.exportsPath", () => {
+    const result = resolveLocalExportsPath(
+      { localExportsPath: "./exports" },
+      { exportsPath: "gs://stag-bucket" },
+      SERVICE_DIR,
+    );
+    expect(result).toBe(path.resolve(SERVICE_DIR, "./exports"));
+  });
+
+  it("falls back to env.exportsPath when localExportsPath is unset", () => {
+    const result = resolveLocalExportsPath(
+      {},
+      { exportsPath: "./exports" },
+      SERVICE_DIR,
+    );
+    expect(result).toBe(path.resolve(SERVICE_DIR, "./exports"));
+  });
+
+  it("resolves relative paths against the service directory", () => {
+    const result = resolveLocalExportsPath(
+      { localExportsPath: "../../shared-exports" },
+      {},
+      SERVICE_DIR,
+    );
+    expect(result).toBe(path.resolve(SERVICE_DIR, "../../shared-exports"));
+  });
+
+  it("passes gs:// URIs through unchanged from localExportsPath", () => {
+    const result = resolveLocalExportsPath(
+      { localExportsPath: "gs://dev-bucket/prefix" },
+      { exportsPath: "gs://stag-bucket" },
+      SERVICE_DIR,
+    );
+    expect(result).toBe("gs://dev-bucket/prefix");
+  });
+
+  it("passes gs:// URIs through unchanged from env.exportsPath fallback", () => {
+    const result = resolveLocalExportsPath(
+      {},
+      { exportsPath: "gs://stag-bucket/sub" },
+      SERVICE_DIR,
+    );
+    expect(result).toBe("gs://stag-bucket/sub");
+  });
+
+  it("preserves existing behaviour when only env.exportsPath is a local path", () => {
+    /** Regression guard for the 1.7.0 behaviour */
+    const result = resolveLocalExportsPath(
+      {},
+      { exportsPath: "./exports" },
+      SERVICE_DIR,
+    );
+    expect(result).toBe(path.resolve(SERVICE_DIR, "./exports"));
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 /** Environment configuration for a specific deployment target */
 export interface RunnerEnvOptions {
   /** GCP project ID — sets GOOGLE_CLOUD_PROJECT automatically */
@@ -16,11 +18,14 @@ export interface RunnerEnvOptions {
    * Destination for artifacts written via `getExportsWriter()`.
    *
    * Either a local path (resolved relative to the service directory) or a
-   * `gs://bucket[/prefix]` URI. Typically set per environment — e.g. a local
-   * directory for development and a bucket for cloud deployments.
+   * `gs://bucket[/prefix]` URI. For most setups this is a `gs://` URI — one
+   * per environment — paired with a top-level `localExportsPath` that
+   * catches every local run regardless of which environment is selected.
    *
-   * When unset, `getExportsWriter()` throws. Local paths are only applied when
-   * running locally; cloud deployments require a `gs://` URI.
+   * When unset, `getExportsWriter()` throws (unless `localExportsPath` is
+   * set and the run is local). Cloud deployments require a `gs://` URI.
+   *
+   * @see RunnerConfig.localExportsPath
    */
   exportsPath?: string;
 }
@@ -84,6 +89,17 @@ export interface RunnerConfig {
   };
   /** Named environments (e.g., stag, prod) */
   environments: Record<string, RunnerEnvOptions>;
+  /**
+   * Destination used by `getExportsWriter()` for every local run, regardless
+   * of which environment is selected. Resolved relative to the service
+   * directory; `gs://bucket[/prefix]` URIs are also accepted.
+   *
+   * When set, local runs ignore the environment's `exportsPath`. When unset,
+   * local runs fall back to the environment's `exportsPath`.
+   *
+   * Cloud runs always use the environment's `exportsPath`.
+   */
+  localExportsPath?: string;
   /** Cloud Run Jobs configuration (required for `job cloud run/deploy` commands) */
   cloud?: CloudConfig;
   /**
@@ -102,4 +118,20 @@ export function defineRunnerConfig(config: RunnerConfig): RunnerConfig {
 /** Identity function for type-safe environment definition */
 export function defineRunnerEnv(options: RunnerEnvOptions): RunnerEnvOptions {
   return options;
+}
+
+/**
+ * Resolve the exports destination for a local run. Prefers the top-level
+ * `localExportsPath` over the environment's `exportsPath`. Local paths are
+ * resolved against the service directory; `gs://` URIs pass through
+ * unchanged.
+ */
+export function resolveLocalExportsPath(
+  config: Pick<RunnerConfig, "localExportsPath">,
+  envConfig: Pick<RunnerEnvOptions, "exportsPath">,
+  serviceDirectory: string,
+): string | undefined {
+  const raw = config.localExportsPath ?? envConfig.exportsPath;
+  if (!raw) return undefined;
+  return raw.startsWith("gs://") ? raw : path.resolve(serviceDirectory, raw);
 }

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -39,8 +39,9 @@ export function getExportsWriter(): ExportsWriter {
   if (!destination) {
     throw new Error(
       "No exports destination configured.\n" +
-        "Set `exportsPath` on the current environment in your job-runner.config.ts, " +
-        "or set JOB_EXPORTS_PATH directly in the environment.",
+        "Set `localExportsPath` or the current environment's `exportsPath` " +
+        "in your job-runner.config.ts, or set JOB_EXPORTS_PATH directly in " +
+        "the environment.",
     );
   }
 


### PR DESCRIPTION
Adds a top-level `localExportsPath` on `RunnerConfig` so local runs can write to a single destination regardless of the selected environment, while cloud runs continue to use each environment's `exportsPath`.

Previously, with only per-environment `exportsPath`, supporting both "local path on disk" and "`gs://` bucket in the cloud" required duplicating every environment into `<env>` and `<env>-cloud` variants. The new field expresses the common split directly: a `gs://` URI per environment, plus one shared local path.

Behaviour:

- When `localExportsPath` is set, local runs use it and ignore the environment's `exportsPath`.
- When unset, local runs fall back to the environment's `exportsPath` (unchanged from 1.7.0).
- Cloud runs always use the environment's `exportsPath`. `assertCloudExportsPath` still rejects local paths for cloud commands.
- Local paths resolve against the service directory; `gs://` URIs pass through.