### PR TITLE
Fix Ctrl+C not exiting interactive prompts

### DIFF
--- a/src/cloud/deploy.ts
+++ b/src/cloud/deploy.ts
@@ -128,6 +128,7 @@ export async function prepareImage(
                 hint: "build remotely instead",
               },
             ],
+            cancel: "symbol",
           },
         );
 

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -86,6 +86,7 @@ export async function selectJob(jobsDirectory: string): Promise<string> {
     const selection = await consola.prompt(prompt, {
       type: "select",
       options: choices,
+      cancel: "symbol",
     });
 
     if (typeof selection === "symbol") {
@@ -162,6 +163,7 @@ async function promptForField(key: string, info: FieldInfo): Promise<unknown> {
       type: "select",
       options,
       initial: info.defaultValue as string,
+      cancel: "symbol",
     });
 
     if (typeof result === "symbol") {
@@ -177,6 +179,7 @@ async function promptForField(key: string, info: FieldInfo): Promise<unknown> {
     const result = await consola.prompt(message, {
       type: "confirm",
       initial: (info.defaultValue as boolean) ?? false,
+      cancel: "symbol",
     });
 
     if (typeof result === "symbol") {
@@ -200,6 +203,7 @@ async function promptForField(key: string, info: FieldInfo): Promise<unknown> {
         initial: info.defaultValue
           ? (info.defaultValue as unknown[]).join(", ")
           : "",
+        cancel: "symbol",
       });
 
       if (typeof result === "symbol") {
@@ -231,6 +235,7 @@ async function promptForField(key: string, info: FieldInfo): Promise<unknown> {
       const result = await consola.prompt(message, {
         type: "text",
         initial: initialValue,
+        cancel: "symbol",
       });
 
       if (typeof result === "symbol") {
@@ -256,6 +261,7 @@ async function promptForField(key: string, info: FieldInfo): Promise<unknown> {
     const result = await consola.prompt(message, {
       type: "text",
       initial: (info.defaultValue as string) ?? "",
+      cancel: "symbol",
     });
 
     if (typeof result === "symbol") {


### PR DESCRIPTION
Interactive prompts did not respond to Ctrl+C or Escape. On required text prompts the loop ran forever, and on selects execution continued as if the first option had been picked.

The cause is that `consola.prompt()` defaults its `cancel` strategy to `"default"`, which resolves a cancelled prompt with the `initial` value rather than a cancel symbol. The existing `typeof result === "symbol"` guards in `selectJob`, `promptForField`, and the Docker daemon prompt therefore never triggered.

Passing `cancel: "symbol"` to each `consola.prompt()` call makes Ctrl+C (and Escape) resolve with `Symbol.for("cancel")`, which the existing code already handles by logging `Cancelled` and exiting with code 0.

Scope: packages (gcp-job-runner)
Visibility: user-facing