### PR TITLE
Add interactive file picker for Zod file fields

### DIFF
--- a/docs/defining-jobs.md
+++ b/docs/defining-jobs.md
@@ -276,7 +276,7 @@ export default defineJob({
 });
 ```
 
-See [File I/O](./files) for the full API and configuration details.
+Mark a schema field with `fileInput()` and interactive mode offers a selectable list of files from the configured input directory instead of a free-text prompt. See [File I/O](./files) for the full API and configuration details.
 
 ## Metadata and Discovery
 

--- a/docs/files.md
+++ b/docs/files.md
@@ -79,6 +79,35 @@ export default defineRunnerConfig({
 
 For `gs://` destinations, use `@google-cloud/storage` directly to fetch objects under the prefix — the library intentionally stays out of the read path so you can stream, list, and filter as your job needs.
 
+### Picking Files Interactively
+
+Mark a schema field with `fileInput()` to turn it into a picker in `--interactive` mode. Interactive runs list the files under the configured `inputFilesPath` (local `readdir` or `gs://` bucket list) and present them as a select prompt instead of asking for a free-text path:
+
+```typescript
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+import { defineJob, fileInput, getInputFilesPath } from "gcp-job-runner";
+
+export default defineJob({
+  description: "Process a CSV from the input directory",
+  schema: z.object({
+    file: fileInput().describe("CSV to process"),
+  }),
+  handler: async ({ file }) => {
+    const base = getInputFilesPath();
+    const raw = await readFile(path.join(base, file), "utf-8");
+    // ...
+  },
+});
+```
+
+Run it with `job local run <env> <job> --interactive` and the `--file` prompt becomes a scrollable list of files in the configured input directory. `fileInput()` chains with `.optional()`, `.default()`, and `.describe()` as usual.
+
+When the destination is a `gs://` URI, the picker uses a lazy `@google-cloud/storage` list — it authenticates with Application Default Credentials on the local machine running the prompt. An empty directory or missing config falls back to a free-text prompt with a warning so the flow isn't blocked.
+
+`listInputFiles()` is also exported if you need the same listing outside the interactive flow.
+
 ### Reading Your Own Output
 
 `getOutputFilesPath()` returns the resolved output destination. Useful when a handler writes a file and then needs its path for a follow-up step, or when chaining steps:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -503,12 +503,28 @@ async function handleCloudRun(options: CloudRunOptions): Promise<void> {
      * while collecting arg values. The container itself gets the env
      * var from the deploy path — this assignment is only for the
      * locally-running prompt.
+     *
+     * Explicitly clear the var when the env doesn't define
+     * `inputFilesPath` so a stale value from the user's shell can't
+     * leak in, and restore the original value once the prompt returns
+     * to keep the process environment unchanged for later steps.
      */
-    if (envConfig.inputFilesPath) {
-      process.env.JOB_INPUT_FILES_PATH = envConfig.inputFilesPath;
+    const previousInputFilesPath = process.env.JOB_INPUT_FILES_PATH;
+    try {
+      if (envConfig.inputFilesPath) {
+        process.env.JOB_INPUT_FILES_PATH = envConfig.inputFilesPath;
+      } else {
+        delete process.env.JOB_INPUT_FILES_PATH;
+      }
+      const result = await resolveInteractiveJob(jobsDirectory);
+      jobArgv = result.jobArgv;
+    } finally {
+      if (previousInputFilesPath === undefined) {
+        delete process.env.JOB_INPUT_FILES_PATH;
+      } else {
+        process.env.JOB_INPUT_FILES_PATH = previousInputFilesPath;
+      }
     }
-    const result = await resolveInteractiveJob(jobsDirectory);
-    jobArgv = result.jobArgv;
   } else {
     if (!jobNameFromArgs) {
       consola.error(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -497,6 +497,16 @@ async function handleCloudRun(options: CloudRunOptions): Promise<void> {
   let jobArgv: string[];
 
   if (isInteractive) {
+    /**
+     * Surface the env's `inputFilesPath` to the interactive picker so
+     * `listInputFiles()` can enumerate the configured (gs://) bucket
+     * while collecting arg values. The container itself gets the env
+     * var from the deploy path — this assignment is only for the
+     * locally-running prompt.
+     */
+    if (envConfig.inputFilesPath) {
+      process.env.JOB_INPUT_FILES_PATH = envConfig.inputFilesPath;
+    }
     const result = await resolveInteractiveJob(jobsDirectory);
     jobArgv = result.jobArgv;
   } else {

--- a/src/files.test.ts
+++ b/src/files.test.ts
@@ -425,7 +425,7 @@ describe("listInputFiles (gcs)", () => {
     const result = await freshList();
 
     expect(bucketMock).toHaveBeenCalledWith("my-bucket");
-    expect(getFilesMock).toHaveBeenCalledWith({ prefix: "inputs" });
+    expect(getFilesMock).toHaveBeenCalledWith({ prefix: "inputs/" });
     expect(result).toEqual(["a.txt", "b.txt", "sub/nested.txt"]);
   });
 
@@ -452,5 +452,22 @@ describe("listInputFiles (gcs)", () => {
     const result = await freshList();
 
     expect(result).toEqual(["a.txt"]);
+  });
+
+  it("passes a delimiter-terminated prefix so sibling folders are excluded", async () => {
+    /**
+     * Regression guard: `inputs` without trailing `/` would also match
+     * sibling keys like `inputs-backup/…`. The terminated prefix makes
+     * GCS scope the list to the intended folder only.
+     */
+    process.env.JOB_INPUT_FILES_PATH = "gs://my-bucket/inputs";
+    getFilesMock.mockResolvedValue([[{ name: "inputs/real.txt" }]]);
+
+    vi.resetModules();
+    const { listInputFiles: freshList } = await import("./files");
+    const result = await freshList();
+
+    expect(getFilesMock).toHaveBeenCalledWith({ prefix: "inputs/" });
+    expect(result).toEqual(["real.txt"]);
   });
 });

--- a/src/files.test.ts
+++ b/src/files.test.ts
@@ -1,9 +1,15 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { consola } from "consola";
-import { getFileWriter, getInputFilesPath, getOutputFilesPath } from "./files";
+import {
+  getFileWriter,
+  getInputFilesPath,
+  getOutputFilesPath,
+  listInputFiles,
+} from "./files";
 
 describe("getFileWriter", () => {
   let tempDir: string;
@@ -332,5 +338,119 @@ describe("getOutputFilesPath", () => {
   it("throws when JOB_OUTPUT_FILES_PATH is unset", () => {
     delete process.env.JOB_OUTPUT_FILES_PATH;
     expect(() => getOutputFilesPath()).toThrowError(/outputFilesPath/);
+  });
+});
+
+describe("listInputFiles (local)", () => {
+  let tempDir: string;
+  const originalInputPath = process.env.JOB_INPUT_FILES_PATH;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "list-input-files-test-"));
+    process.env.JOB_INPUT_FILES_PATH = tempDir;
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    if (originalInputPath === undefined) {
+      delete process.env.JOB_INPUT_FILES_PATH;
+    } else {
+      process.env.JOB_INPUT_FILES_PATH = originalInputPath;
+    }
+  });
+
+  it("returns sorted top-level filenames", async () => {
+    writeFileSync(path.join(tempDir, "b.txt"), "b");
+    writeFileSync(path.join(tempDir, "a.txt"), "a");
+    writeFileSync(path.join(tempDir, "c.json"), "{}");
+
+    expect(await listInputFiles()).toEqual(["a.txt", "b.txt", "c.json"]);
+  });
+
+  it("skips subdirectories", async () => {
+    writeFileSync(path.join(tempDir, "root.txt"), "x");
+    await mkdir(path.join(tempDir, "sub"));
+    writeFileSync(path.join(tempDir, "sub", "nested.txt"), "y");
+
+    expect(await listInputFiles()).toEqual(["root.txt"]);
+  });
+
+  it("returns an empty array for an empty directory", async () => {
+    expect(await listInputFiles()).toEqual([]);
+  });
+
+  it("throws when JOB_INPUT_FILES_PATH is unset", async () => {
+    delete process.env.JOB_INPUT_FILES_PATH;
+    await expect(listInputFiles()).rejects.toThrow(/inputFilesPath/);
+  });
+});
+
+describe("listInputFiles (gcs)", () => {
+  const originalInputPath = process.env.JOB_INPUT_FILES_PATH;
+  const getFilesMock = vi.fn();
+  const bucketMock = vi.fn(() => ({ getFiles: getFilesMock }));
+
+  beforeEach(() => {
+    getFilesMock.mockReset();
+    bucketMock.mockClear();
+    vi.doMock("@google-cloud/storage", () => ({
+      Storage: class {
+        bucket = bucketMock;
+      },
+    }));
+  });
+
+  afterEach(() => {
+    vi.doUnmock("@google-cloud/storage");
+    vi.resetModules();
+    if (originalInputPath === undefined) {
+      delete process.env.JOB_INPUT_FILES_PATH;
+    } else {
+      process.env.JOB_INPUT_FILES_PATH = originalInputPath;
+    }
+  });
+
+  it("lists objects under the configured prefix, stripped and sorted", async () => {
+    process.env.JOB_INPUT_FILES_PATH = "gs://my-bucket/inputs";
+    getFilesMock.mockResolvedValue([
+      [
+        { name: "inputs/b.txt" },
+        { name: "inputs/a.txt" },
+        { name: "inputs/sub/nested.txt" },
+      ],
+    ]);
+
+    vi.resetModules();
+    const { listInputFiles: freshList } = await import("./files");
+    const result = await freshList();
+
+    expect(bucketMock).toHaveBeenCalledWith("my-bucket");
+    expect(getFilesMock).toHaveBeenCalledWith({ prefix: "inputs" });
+    expect(result).toEqual(["a.txt", "b.txt", "sub/nested.txt"]);
+  });
+
+  it("lists bucket-only destinations with no prefix", async () => {
+    process.env.JOB_INPUT_FILES_PATH = "gs://my-bucket";
+    getFilesMock.mockResolvedValue([[{ name: "a.txt" }, { name: "b.txt" }]]);
+
+    vi.resetModules();
+    const { listInputFiles: freshList } = await import("./files");
+    const result = await freshList();
+
+    expect(getFilesMock).toHaveBeenCalledWith({ prefix: undefined });
+    expect(result).toEqual(["a.txt", "b.txt"]);
+  });
+
+  it("drops GCS folder-marker entries", async () => {
+    process.env.JOB_INPUT_FILES_PATH = "gs://my-bucket/inputs";
+    getFilesMock.mockResolvedValue([
+      [{ name: "inputs/" }, { name: "inputs/a.txt" }, { name: "inputs/sub/" }],
+    ]);
+
+    vi.resetModules();
+    const { listInputFiles: freshList } = await import("./files");
+    const result = await freshList();
+
+    expect(result).toEqual(["a.txt"]);
   });
 });

--- a/src/files.ts
+++ b/src/files.ts
@@ -1,6 +1,7 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { consola } from "consola";
+import { z } from "zod";
 import type { Storage } from "@google-cloud/storage";
 
 /**
@@ -72,6 +73,71 @@ export function getFileWriter(): FileWriter {
   }
 
   return createLocalWriter(destination);
+}
+
+/**
+ * Mark a Zod string field as a file input. Interactive mode detects this
+ * marker and offers a selectable list of files from `getInputFilesPath()`
+ * instead of a free-text prompt.
+ *
+ * ```ts
+ * z.object({
+ *   file: fileInput().describe("CSV to process"),
+ * });
+ * ```
+ *
+ * Chains with `.describe()`, `.optional()`, `.default()` as usual.
+ */
+export function fileInput() {
+  return z.string().meta({ kind: "file" });
+}
+
+/**
+ * List filenames available under the configured input files destination.
+ * Returns names relative to the destination directory (no leading slash).
+ * Results are sorted alphabetically.
+ *
+ * Local destinations list only top-level files (nested directories are
+ * skipped for now). `gs://` destinations list every object under the
+ * configured prefix.
+ *
+ * Throws when no input destination is configured.
+ */
+export async function listInputFiles(): Promise<string[]> {
+  const destination = readInputDestination();
+  if (destination.startsWith(GCS_PREFIX)) {
+    return listGcsFiles(destination);
+  }
+  return listLocalFiles(path.resolve(destination));
+}
+
+async function listLocalFiles(basePath: string): Promise<string[]> {
+  const entries = await readdir(basePath, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name)
+    .sort();
+}
+
+async function listGcsFiles(uri: string): Promise<string[]> {
+  const { bucket, prefix } = parseGcsUri(uri);
+  const storage = await getStorageClient();
+  const [files] = await storage.bucket(bucket).getFiles({
+    prefix: prefix || undefined,
+  });
+
+  /**
+   * `file.name` is a full object key including the prefix. Strip the
+   * prefix (plus the separator) so callers receive a name relative to
+   * the configured destination, mirroring how the writer addresses
+   * objects.
+   */
+  const stripLen = prefix ? prefix.length + 1 : 0;
+
+  return files
+    .map((file) => file.name.slice(stripLen))
+    .filter((name) => name.length > 0 && !name.endsWith("/"))
+    .sort();
 }
 
 function resolveDestination(destination: string): string {

--- a/src/files.ts
+++ b/src/files.ts
@@ -121,18 +121,19 @@ async function listLocalFiles(basePath: string): Promise<string[]> {
 
 async function listGcsFiles(uri: string): Promise<string[]> {
   const { bucket, prefix } = parseGcsUri(uri);
-  const storage = await getStorageClient();
-  const [files] = await storage.bucket(bucket).getFiles({
-    prefix: prefix || undefined,
-  });
 
   /**
-   * `file.name` is a full object key including the prefix. Strip the
-   * prefix (plus the separator) so callers receive a name relative to
-   * the configured destination, mirroring how the writer addresses
-   * objects.
+   * Terminate the list prefix with `/` so GCS treats it as a folder and
+   * not a bare substring — otherwise a configured `inputs` would also
+   * match sibling keys like `inputs2/…` or `inputs-backup/…`.
    */
-  const stripLen = prefix ? prefix.length + 1 : 0;
+  const listPrefix = prefix ? `${prefix}/` : undefined;
+  const stripLen = listPrefix ? listPrefix.length : 0;
+
+  const storage = await getStorageClient();
+  const [files] = await storage.bucket(bucket).getFiles({
+    prefix: listPrefix,
+  });
 
   return files
     .map((file) => file.name.slice(stripLen))

--- a/src/help.test.ts
+++ b/src/help.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
+import { fileInput } from "./files";
 import {
+  extractFieldInfo,
   formatZodError,
   generateFullHelp,
   generateSchemaHelp,
@@ -151,5 +153,43 @@ describe("generateFullHelp", () => {
     expect(help).toContain("Examples:");
     expect(help).toContain("  pnpm cli:stag api/search --from AMS");
     expect(help).toContain("  pnpm cli:stag api/search --from AMS --to LHR");
+  });
+});
+
+describe("extractFieldInfo for fileInput()", () => {
+  it("marks a bare fileInput() field with kind: 'file'", () => {
+    const info = extractFieldInfo(fileInput());
+    expect(info.typeName).toBe("string");
+    expect(info.kind).toBe("file");
+    expect(info.isOptional).toBe(false);
+  });
+
+  it("preserves kind through .describe()", () => {
+    const info = extractFieldInfo(fileInput().describe("CSV to process"));
+    expect(info.kind).toBe("file");
+    expect(info.description).toBe("CSV to process");
+  });
+
+  it("preserves kind through .optional()", () => {
+    const info = extractFieldInfo(fileInput().optional());
+    expect(info.kind).toBe("file");
+    expect(info.isOptional).toBe(true);
+  });
+
+  it("preserves kind through .default()", () => {
+    const info = extractFieldInfo(fileInput().default("input.csv"));
+    expect(info.kind).toBe("file");
+    expect(info.isOptional).toBe(true);
+    expect(info.defaultValue).toBe("input.csv");
+  });
+
+  it("does not set kind for a plain string field", () => {
+    const info = extractFieldInfo(z.string());
+    expect(info.kind).toBeUndefined();
+  });
+
+  it("ignores meta without a recognized kind", () => {
+    const info = extractFieldInfo(z.string().meta({ kind: "something" }));
+    expect(info.kind).toBeUndefined();
   });
 });

--- a/src/help.ts
+++ b/src/help.ts
@@ -21,6 +21,12 @@ export interface FieldInfo {
   isOptional: boolean;
   defaultValue?: unknown;
   enumValues?: string[];
+  /**
+   * Custom role assigned via `.meta({ kind: ... })` on the Zod schema.
+   * Used by interactive mode to switch prompt strategies — e.g. `"file"`
+   * triggers the input-files picker instead of a free-text prompt.
+   */
+  kind?: "file";
 }
 
 /** Schema type with description property */
@@ -184,6 +190,18 @@ export function extractFieldInfo(schema: ZodType): FieldInfo {
   /** Get description */
   const originalSchema = schema as ZodTypeWithDescription;
   info.description = originalSchema.description ?? current.description;
+
+  /**
+   * Read Zod 4 `.meta()` metadata from the unwrapped inner schema so
+   * `fileInput().optional()` / `.default()` still surface `kind: "file"`.
+   */
+  const meta = (current as ZodType).meta();
+  if (meta && typeof meta === "object") {
+    const kind = (meta as { kind?: unknown }).kind;
+    if (kind === "file") {
+      info.kind = "file";
+    }
+  }
 
   /** Get type name */
   const typeName = getType(def);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,13 @@
 export { defineRunnerConfig, defineRunnerEnv } from "./config";
 export { defineJob } from "./define-job";
 export { discoverJobs } from "./discover-jobs";
-export { getFileWriter, getInputFilesPath, getOutputFilesPath } from "./files";
+export {
+  fileInput,
+  getFileWriter,
+  getInputFilesPath,
+  getOutputFilesPath,
+  listInputFiles,
+} from "./files";
 export type { FileWriter } from "./files";
 export {
   extractFieldInfo,

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -319,7 +319,16 @@ async function promptForFileInput(
     return { handled: false };
   }
 
-  const SKIP = "__skip__";
+  /**
+   * Pick a sentinel that can't collide with a real filename in the
+   * listing — `__skip__.csv` is an unlikely but legal filename, so we
+   * extend with `_N` suffixes until the candidate is unique.
+   */
+  const existing = new Set(files);
+  let SKIP = "__skip__";
+  for (let n = 1; existing.has(SKIP); n += 1) {
+    SKIP = `__skip_${n}__`;
+  }
   const options = files.map((name) => ({ label: name, value: name }));
   if (info.isOptional) {
     options.unshift({ label: "(skip)", value: SKIP });

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -2,6 +2,7 @@ import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import { consola } from "consola";
 import type { ZodObject, ZodRawShape, ZodType } from "zod";
+import { listInputFiles } from "./files";
 import { extractFieldInfo, type FieldInfo, toKebabCase } from "./help";
 
 /**
@@ -147,6 +148,13 @@ async function promptForField(key: string, info: FieldInfo): Promise<unknown> {
     ? `${optionalPrefix}--${flagName} · ${info.description}${defaultSuffix}`
     : `${optionalPrefix}--${flagName}${defaultSuffix}`;
 
+  /** Handle file-input fields with a picker over the configured inputFilesPath */
+  if (info.kind === "file") {
+    const picked = await promptForFileInput(message, info);
+    if (picked.handled) return picked.value;
+    /** Fall through to the default text prompt when the picker can't run. */
+  }
+
   /** Handle enum type with select prompt */
   if (
     info.typeName === "enum" &&
@@ -279,4 +287,56 @@ async function promptForField(key: string, info: FieldInfo): Promise<unknown> {
 
     return result;
   }
+}
+
+/**
+ * Picker result. `handled: true` means the user interacted with the
+ * picker (selected a file or skipped an optional field) and `value` is
+ * the final answer. `handled: false` means the picker couldn't run
+ * (no configured destination, empty directory, listing failure) — the
+ * caller should fall through to a free-text prompt.
+ */
+type FilePickerResult =
+  | { handled: true; value: string | undefined }
+  | { handled: false };
+
+async function promptForFileInput(
+  message: string,
+  info: FieldInfo,
+): Promise<FilePickerResult> {
+  let files: string[];
+  try {
+    files = await listInputFiles();
+  } catch (error) {
+    consola.warn(
+      `Couldn't list input files: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return { handled: false };
+  }
+
+  if (files.length === 0) {
+    consola.warn("No files found at the configured inputFilesPath");
+    return { handled: false };
+  }
+
+  const SKIP = "__skip__";
+  const options = files.map((name) => ({ label: name, value: name }));
+  if (info.isOptional) {
+    options.unshift({ label: "(skip)", value: SKIP });
+  }
+
+  const result = await consola.prompt(message, {
+    type: "select",
+    options,
+    initial:
+      typeof info.defaultValue === "string" ? info.defaultValue : undefined,
+    cancel: "symbol",
+  });
+
+  if (typeof result === "symbol") {
+    consola.info("Cancelled");
+    process.exit(0);
+  }
+
+  return { handled: true, value: result === SKIP ? undefined : result };
 }


### PR DESCRIPTION
Adds a `fileInput()` helper for marking Zod schema fields as file inputs. When a job with such a field is run with `--interactive`, the CLI lists files under the configured `inputFilesPath` and offers them in a select prompt instead of asking for a free-text path.

Marker shape: `fileInput()` returns `z.string().meta({ kind: "file" })`. Chains with `.describe()` / `.optional()` / `.default()`. `FieldInfo` gains a `kind?: "file"` slot, populated by `extractFieldInfo()` after the existing unwraps for `optional` / `default` / `ZodEffects`.

Listing: local destinations use `readdir` and skip subdirectories; `gs://` destinations use a lazy `@google-cloud/storage` `getFiles({ prefix })` call, reusing `parseGcsUri()` and `getStorageClient()`. Folder-marker objects and the prefix itself are stripped. `listInputFiles()` is exported for use outside the interactive flow.

Flow: the picker falls through to the default text prompt when the destination is unconfigured, empty, or listing fails — it never blocks. Cancellation follows the existing `cancel: "symbol"` pattern established in #26. For cloud-interactive runs the CLI sets `JOB_INPUT_FILES_PATH` locally before calling the resolver so the picker can enumerate the configured `gs://` bucket; the container still receives the env var via the deploy path.

Scope: packages (gcp-job-runner)
Visibility: user-facing