### PR TITLE
Add input-file read helpers to match the writer API

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Same code, same arguments, same secrets. The cloud command automatically builds 
 - **Cloud Run deployment** — no Terraform or manual GCP config needed, just `job cloud run`
 - **Smart caching** — a single Docker image contains all jobs; running different jobs or different arguments doesn't rebuild
 - **GCP Secret Manager** — secrets are loaded transparently for both local and cloud execution
-- **Unified file I/O** — `getFileWriter()` writes JSON/CSV/binary to a configured output location and `getInputFilesPath()` exposes the input location for reads, targeting local directories during development and Cloud Storage buckets in production with the same handler code
+- **Unified file I/O** — `getFileWriter()` writes JSON/CSV/binary to a configured output location and `readInputJson()` / `readInputText()` / `readInputBuffer()` read from a configured input location, targeting local directories during development and Cloud Storage buckets in production with the same handler code
 - **Multi-environment** — configure staging, production, etc. and switch with a single argument
 
 ## Install

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -63,15 +63,16 @@ When browsing jobs:
 
 The prompts adapt to the schema field types:
 
-| Field Type | Prompt Type                         |
-| ---------- | ----------------------------------- |
-| `string`   | Text input                          |
-| `number`   | Text input (parsed as number)       |
-| `boolean`  | Yes/No confirmation                 |
-| `enum`     | Select from allowed values          |
-| `array`    | Text input (comma-separated values) |
+| Field Type      | Prompt Type                                             |
+| --------------- | ------------------------------------------------------- |
+| `string`        | Text input                                              |
+| `number`        | Text input (parsed as number)                           |
+| `boolean`       | Yes/No confirmation                                     |
+| `enum`          | Select from allowed values                              |
+| `array`         | Text input (comma-separated values)                     |
+| `fileInput()`   | Select from files in the configured `inputFilesPath`    |
 
-Optional fields can be skipped by pressing Enter without a value. Default values are shown and pre-filled when available.
+Optional fields can be skipped by pressing Enter without a value. Default values are shown and pre-filled when available. Fields marked with `fileInput()` (see [File I/O](./files)) offer a select prompt of the files found under the configured input destination; if the directory is empty or unconfigured, the prompt falls back to free-text entry.
 
 ### Cloud Interactive Mode
 

--- a/docs/cloud-jobs.md
+++ b/docs/cloud-jobs.md
@@ -46,7 +46,7 @@ export default defineRunnerConfig({
 });
 ```
 
-`inputFilesPath` and `outputFilesPath` are both optional and independent — set the ones your jobs actually use via [`getInputFilesPath()` / `getFileWriter()` / `getOutputFilesPath()`](./files). Cloud environments require `gs://` URIs for these; attempting to deploy with a local path fails fast with a clear error.
+`inputFilesPath` and `outputFilesPath` are both optional and independent — set the ones your jobs actually use via the [File I/O helpers](./files) (`readInputJson` / `readInputText` / `readInputBuffer` / `getInputFilesPath` for reads, `getFileWriter` / `getOutputFilesPath` for writes). Cloud environments require `gs://` URIs for these; attempting to deploy with a local path fails fast with a clear error.
 
 ### 2. Add Build Entry for Jobs
 

--- a/docs/defining-jobs.md
+++ b/docs/defining-jobs.md
@@ -261,7 +261,7 @@ export default defineJob({
 
 ## File I/O
 
-Jobs that produce or consume files (reports, exports, fixtures, prior outputs) can use `getFileWriter()` to write JSON, CSV, or binary content to the configured output destination, and `getInputFilesPath()` to locate files for reading. Destinations are configured per environment — local directories during development, Cloud Storage buckets in production.
+Jobs that produce or consume files (reports, exports, fixtures, prior outputs) can use `getFileWriter()` to write JSON, CSV, or binary content to the configured output destination, and `readInputJson()` / `readInputText()` / `readInputBuffer()` to read from the configured input destination (falling back to `getInputFilesPath()` for streaming or custom access). Destinations are configured per environment — local directories during development, Cloud Storage buckets in production.
 
 ```typescript
 import { defineJob, getFileWriter } from "gcp-job-runner";

--- a/docs/files.md
+++ b/docs/files.md
@@ -96,7 +96,7 @@ For formats the library doesn't ship a helper for (e.g. CSV), read the text and 
 import { readInputText } from "gcp-job-runner";
 import Papa from "papaparse";
 
-const rows = Papa.parse(await readInputText("users.csv"), { header: true });
+const rows = Papa.parse(await readInputText("users.csv"), { header: true }).data;
 ```
 
 ### Streaming or Custom Access

--- a/docs/files.md
+++ b/docs/files.md
@@ -46,18 +46,19 @@ export default defineRunnerConfig({
 
 ## Reading Input Files
 
-Use `getInputFilesPath()` to get the resolved input destination and read with whatever API fits:
+Most jobs read JSON or plain text. Use `readInputJson()` / `readInputText()` / `readInputBuffer()` — they transparently handle local directories and `gs://` buckets, reject absolute paths and upward traversal, and throw the same "no input destination configured" error as the writer when nothing is set:
 
 ```typescript
-import { readFile } from "node:fs/promises";
-import path from "node:path";
-import { defineJob, getInputFilesPath } from "gcp-job-runner";
+import { defineJob, readInputJson } from "gcp-job-runner";
+
+interface Airline {
+  iata: string;
+  name: string;
+}
 
 export default defineJob({
   handler: async () => {
-    const base = getInputFilesPath();
-    const raw = await readFile(path.join(base, "airlines.json"), "utf-8");
-    const airlines = JSON.parse(raw);
+    const airlines = await readInputJson<Airline[]>("airlines.json");
     // ...
   },
 });
@@ -77,17 +78,49 @@ export default defineRunnerConfig({
 });
 ```
 
-For `gs://` destinations, use `@google-cloud/storage` directly to fetch objects under the prefix — the library intentionally stays out of the read path so you can stream, list, and filter as your job needs.
+### Reader API
+
+```typescript
+function readInputText(relativePath: string): Promise<string>;
+function readInputJson<T = unknown>(relativePath: string): Promise<T>;
+function readInputBuffer(relativePath: string): Promise<Buffer>;
+```
+
+- `readInputText` returns the file contents decoded as UTF-8. Use for CSV, JSON, plain text, SVG — anything character-based.
+- `readInputJson` is a thin wrapper that parses the decoded text; parse errors on malformed input propagate as standard `SyntaxError`s from `JSON.parse`.
+- `readInputBuffer` returns the raw bytes — use for binary inputs (PNG, protobuf, etc.).
+
+For formats the library doesn't ship a helper for (e.g. CSV), read the text and feed it to your preferred parser:
+
+```typescript
+import { readInputText } from "gcp-job-runner";
+import Papa from "papaparse";
+
+const rows = Papa.parse(await readInputText("users.csv"), { header: true });
+```
+
+### Streaming or Custom Access
+
+When the file is too large to buffer or you need a streaming API — `@google-cloud/storage` read streams, `createReadStream`, `readdir` of a subdirectory — fall back to `getInputFilesPath()` and pair it with `node:fs` or `@google-cloud/storage` directly:
+
+```typescript
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { getInputFilesPath } from "gcp-job-runner";
+
+const base = getInputFilesPath();
+const raw = await readFile(path.join(base, "airlines.json"), "utf-8");
+```
+
+The readers above cover the common case; `getInputFilesPath()` is the escape hatch.
 
 ### Picking Files Interactively
 
 Mark a schema field with `fileInput()` to turn it into a picker in `--interactive` mode. Interactive runs list the files under the configured `inputFilesPath` (local `readdir` or `gs://` bucket list) and present them as a select prompt instead of asking for a free-text path:
 
 ```typescript
-import { readFile } from "node:fs/promises";
-import path from "node:path";
 import { z } from "zod";
-import { defineJob, fileInput, getInputFilesPath } from "gcp-job-runner";
+import { defineJob, fileInput, readInputText } from "gcp-job-runner";
 
 export default defineJob({
   description: "Process a CSV from the input directory",
@@ -95,8 +128,7 @@ export default defineJob({
     file: fileInput().describe("CSV to process"),
   }),
   handler: async ({ file }) => {
-    const base = getInputFilesPath();
-    const raw = await readFile(path.join(base, file), "utf-8");
+    const csv = await readInputText(file);
     // ...
   },
 });

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,8 +70,8 @@ features:
         <polyline points="7 10 12 15 17 10"/>
         <line x1="12" x2="12" y1="15" y2="3"/>
       </svg>
-    title: Unified Artifact Output
-    details: Write JSON, CSV, or binary artifacts with one API that targets a local directory during development and a Cloud Storage bucket in production. Same handler code.
+    title: Unified File I/O
+    details: Read and write JSON, CSV, or binary files with one API that targets a local directory during development and a Cloud Storage bucket in production. Same handler code.
 ---
 
 ## Quick Look

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -104,7 +104,7 @@ export default defineRunnerConfig({
 });
 ```
 
-`inputFilesPath` and `outputFilesPath` are both optional and only needed if your jobs call [`getInputFilesPath()`](./files) or [`getFileWriter()` / `getOutputFilesPath()`](./files). For a local-only environment, use relative paths such as `"./input"` / `"./output"` instead of bucket URIs.
+`inputFilesPath` and `outputFilesPath` are both optional and only needed if your jobs read or write files via the [File I/O helpers](./files) (`readInputJson` / `readInputText` / `getFileWriter`, etc.). For a local-only environment, use relative paths such as `"./input"` / `"./output"` instead of bucket URIs.
 
 ## Secrets
 

--- a/docs/schema-validation.md
+++ b/docs/schema-validation.md
@@ -15,6 +15,10 @@ Job arguments are validated using [Zod](https://zod.dev) schemas. This page cove
 
 All of these can be combined with `.optional()`, `.default()`, and `.describe()`.
 
+### Library Helpers
+
+The library also exports `fileInput()`, which returns `z.string().meta({ kind: "file" })`. It behaves like a plain string at validation time, but is picked up by interactive mode as a select prompt over the configured input destination — see [File I/O](./files#picking-files-interactively) for the full example.
+
 ## How `parseArgs` Mapping Works
 
 The `schemaToParseArgsOptions()` function converts a Zod schema into options for Node's built-in `parseArgs`:

--- a/src/files.test.ts
+++ b/src/files.test.ts
@@ -558,6 +558,15 @@ describe("readInputText / readInputJson / readInputBuffer (local)", () => {
     delete process.env.JOB_INPUT_FILES_PATH;
     await expect(readInputText("notes.txt")).rejects.toThrow(/inputFilesPath/);
   });
+
+  it("throws the standard unconfigured error when JOB_INPUT_FILES_PATH is empty", async () => {
+    process.env.JOB_INPUT_FILES_PATH = "";
+    await expect(readInputText("notes.txt")).rejects.toThrow(/inputFilesPath/);
+    await expect(readInputJson("notes.txt")).rejects.toThrow(/inputFilesPath/);
+    await expect(readInputBuffer("notes.txt")).rejects.toThrow(
+      /inputFilesPath/,
+    );
+  });
 });
 
 describe("readInputText / readInputJson / readInputBuffer (gcs)", () => {

--- a/src/files.test.ts
+++ b/src/files.test.ts
@@ -9,6 +9,9 @@ import {
   getInputFilesPath,
   getOutputFilesPath,
   listInputFiles,
+  readInputBuffer,
+  readInputJson,
+  readInputText,
 } from "./files";
 
 describe("getFileWriter", () => {
@@ -469,5 +472,177 @@ describe("listInputFiles (gcs)", () => {
 
     expect(getFilesMock).toHaveBeenCalledWith({ prefix: "inputs/" });
     expect(result).toEqual(["real.txt"]);
+  });
+});
+
+describe("readInputText / readInputJson / readInputBuffer (local)", () => {
+  let tempDir: string;
+  const originalInputPath = process.env.JOB_INPUT_FILES_PATH;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "read-input-test-"));
+    process.env.JOB_INPUT_FILES_PATH = tempDir;
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    if (originalInputPath === undefined) {
+      delete process.env.JOB_INPUT_FILES_PATH;
+    } else {
+      process.env.JOB_INPUT_FILES_PATH = originalInputPath;
+    }
+  });
+
+  it("readInputText returns file contents decoded as UTF-8", async () => {
+    writeFileSync(path.join(tempDir, "notes.txt"), "héllo\nworld");
+    expect(await readInputText("notes.txt")).toBe("héllo\nworld");
+  });
+
+  it("readInputJson parses JSON", async () => {
+    writeFileSync(path.join(tempDir, "data.json"), '{"count":42,"ok":true}');
+    expect(await readInputJson("data.json")).toEqual({ count: 42, ok: true });
+  });
+
+  it("readInputJson preserves the generic type parameter", async () => {
+    interface Row {
+      id: number;
+    }
+    writeFileSync(path.join(tempDir, "rows.json"), '[{"id":1},{"id":2}]');
+    const rows = await readInputJson<Row[]>("rows.json");
+    expect(rows.map((row) => row.id)).toEqual([1, 2]);
+  });
+
+  it("readInputJson surfaces parse errors from malformed input", async () => {
+    writeFileSync(path.join(tempDir, "bad.json"), "{not json");
+    await expect(readInputJson("bad.json")).rejects.toThrow(SyntaxError);
+  });
+
+  it("readInputBuffer returns raw bytes unchanged", async () => {
+    const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0xff]);
+    writeFileSync(path.join(tempDir, "blob.bin"), bytes);
+    const result = await readInputBuffer("blob.bin");
+    expect(result.equals(bytes)).toBe(true);
+  });
+
+  it("resolves nested relative paths under the destination", async () => {
+    await mkdir(path.join(tempDir, "db", "airlines"), { recursive: true });
+    writeFileSync(
+      path.join(tempDir, "db", "airlines", "UA.json"),
+      '{"iata":"UA"}',
+    );
+    expect(await readInputJson("db/airlines/UA.json")).toEqual({ iata: "UA" });
+  });
+
+  it("rejects absolute paths", async () => {
+    await expect(readInputText("/etc/passwd")).rejects.toThrow(
+      /Absolute paths are not allowed/,
+    );
+  });
+
+  it("rejects upward traversal", async () => {
+    await expect(readInputText("../escape.txt")).rejects.toThrow(
+      /must not traverse upward/,
+    );
+    await expect(readInputText("a/../../escape.txt")).rejects.toThrow(
+      /must not traverse upward/,
+    );
+  });
+
+  it("rejects empty paths", async () => {
+    await expect(readInputText("")).rejects.toThrow(/empty/);
+    await expect(readInputJson("")).rejects.toThrow(/empty/);
+    await expect(readInputBuffer("")).rejects.toThrow(/empty/);
+  });
+
+  it("throws the standard unconfigured error when JOB_INPUT_FILES_PATH is unset", async () => {
+    delete process.env.JOB_INPUT_FILES_PATH;
+    await expect(readInputText("notes.txt")).rejects.toThrow(/inputFilesPath/);
+  });
+});
+
+describe("readInputText / readInputJson / readInputBuffer (gcs)", () => {
+  const originalInputPath = process.env.JOB_INPUT_FILES_PATH;
+  const downloadMock = vi.fn();
+  const fileMock = vi.fn(() => ({ download: downloadMock }));
+  const bucketMock = vi.fn(() => ({ file: fileMock }));
+
+  beforeEach(() => {
+    downloadMock.mockReset();
+    fileMock.mockClear();
+    bucketMock.mockClear();
+    vi.doMock("@google-cloud/storage", () => ({
+      Storage: class {
+        bucket = bucketMock;
+      },
+    }));
+  });
+
+  afterEach(() => {
+    vi.doUnmock("@google-cloud/storage");
+    vi.resetModules();
+    if (originalInputPath === undefined) {
+      delete process.env.JOB_INPUT_FILES_PATH;
+    } else {
+      process.env.JOB_INPUT_FILES_PATH = originalInputPath;
+    }
+  });
+
+  it("downloads the object and decodes it as text", async () => {
+    process.env.JOB_INPUT_FILES_PATH = "gs://my-bucket/inputs";
+    downloadMock.mockResolvedValue([Buffer.from("hello cloud", "utf8")]);
+
+    vi.resetModules();
+    const { readInputText: freshText } = await import("./files");
+    const result = await freshText("notes.txt");
+
+    expect(bucketMock).toHaveBeenCalledWith("my-bucket");
+    expect(fileMock).toHaveBeenCalledWith("inputs/notes.txt");
+    expect(result).toBe("hello cloud");
+  });
+
+  it("parses JSON downloaded from the configured bucket", async () => {
+    process.env.JOB_INPUT_FILES_PATH = "gs://my-bucket/inputs";
+    downloadMock.mockResolvedValue([Buffer.from('{"count":7}', "utf8")]);
+
+    vi.resetModules();
+    const { readInputJson: freshJson } = await import("./files");
+    const result = await freshJson<{ count: number }>("report.json");
+
+    expect(fileMock).toHaveBeenCalledWith("inputs/report.json");
+    expect(result).toEqual({ count: 7 });
+  });
+
+  it("returns the raw buffer without decoding", async () => {
+    process.env.JOB_INPUT_FILES_PATH = "gs://my-bucket/inputs";
+    const bytes = Buffer.from([0x00, 0xff, 0x10]);
+    downloadMock.mockResolvedValue([bytes]);
+
+    vi.resetModules();
+    const { readInputBuffer: freshBuffer } = await import("./files");
+    const result = await freshBuffer("blob.bin");
+
+    expect(result.equals(bytes)).toBe(true);
+  });
+
+  it("handles bucket-only URIs (no prefix)", async () => {
+    process.env.JOB_INPUT_FILES_PATH = "gs://my-bucket";
+    downloadMock.mockResolvedValue([Buffer.from("x", "utf8")]);
+
+    vi.resetModules();
+    const { readInputText: freshText } = await import("./files");
+    await freshText("a.txt");
+
+    expect(fileMock).toHaveBeenCalledWith("a.txt");
+  });
+
+  it("rejects traversal before issuing the download", async () => {
+    process.env.JOB_INPUT_FILES_PATH = "gs://my-bucket/inputs";
+
+    vi.resetModules();
+    const { readInputText: freshText } = await import("./files");
+    await expect(freshText("../secret.txt")).rejects.toThrow(
+      /must not traverse upward/,
+    );
+    expect(downloadMock).not.toHaveBeenCalled();
   });
 });

--- a/src/files.ts
+++ b/src/files.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { consola } from "consola";
 import { z } from "zod";
@@ -109,6 +109,71 @@ export async function listInputFiles(): Promise<string[]> {
     return listGcsFiles(destination);
   }
   return listLocalFiles(path.resolve(destination));
+}
+
+/**
+ * Read a file from the configured input files destination as raw bytes.
+ * Local paths and `gs://` URIs are handled transparently.
+ *
+ * `relativePath` is sanitized the same way the writer sanitizes output
+ * paths — absolute paths and upward traversal (`..`) are rejected so a
+ * job can't escape its configured destination.
+ *
+ * Throws when no input destination is configured.
+ */
+export async function readInputBuffer(relativePath: string): Promise<Buffer> {
+  return readInputRaw(relativePath);
+}
+
+/**
+ * Read a UTF-8 text file from the configured input files destination.
+ * Use this for CSV, JSON, plain text, SVG — anything character-based.
+ *
+ * See `readInputBuffer()` for path-sanitization and configuration
+ * semantics.
+ */
+export async function readInputText(relativePath: string): Promise<string> {
+  const buffer = await readInputRaw(relativePath);
+  return buffer.toString("utf8");
+}
+
+/**
+ * Read and `JSON.parse` a file from the configured input files
+ * destination. Parse errors from a malformed file propagate as the
+ * standard `SyntaxError` thrown by `JSON.parse`.
+ *
+ * See `readInputBuffer()` for path-sanitization and configuration
+ * semantics.
+ */
+export async function readInputJson<T = unknown>(
+  relativePath: string,
+): Promise<T> {
+  const text = await readInputText(relativePath);
+  return JSON.parse(text) as T;
+}
+
+async function readInputRaw(relativePath: string): Promise<Buffer> {
+  const destination = readInputDestination();
+  const safeRelative = sanitizeRelativePath(relativePath);
+
+  if (destination.startsWith(GCS_PREFIX)) {
+    return readGcsObject(destination, safeRelative);
+  }
+
+  return readFile(path.join(path.resolve(destination), safeRelative));
+}
+
+async function readGcsObject(
+  uri: string,
+  safeRelative: string,
+): Promise<Buffer> {
+  const { bucket, prefix } = parseGcsUri(uri);
+  const storage = await getStorageClient();
+  const [buf] = await storage
+    .bucket(bucket)
+    .file(joinGcsPath(prefix, safeRelative))
+    .download();
+  return buf;
 }
 
 async function listLocalFiles(basePath: string): Promise<string[]> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,9 @@ export {
   getInputFilesPath,
   getOutputFilesPath,
   listInputFiles,
+  readInputBuffer,
+  readInputJson,
+  readInputText,
 } from "./files";
 export type { FileWriter } from "./files";
 export {


### PR DESCRIPTION
Adds `readInputText`, `readInputJson`, and `readInputBuffer` for reading from the configured `inputFilesPath`. The library already shipped a symmetrical write API (`getFileWriter()` with `writeJson` / `writeText` / `writeBuffer` that transparently targets a local directory or `gs://` bucket); the read side was the missing half, forcing consumers to repeat the `readFile` + `@google-cloud/storage` + traversal-guard plumbing in every import script.

The three readers share an internal resolver that reuses the existing `readInputDestination()`, `sanitizeRelativePath()`, `parseGcsUri()`, `joinGcsPath()`, and lazy `getStorageClient()` helpers. Behavior matches the writer: absolute paths and upward traversal are rejected, and the "no input destination configured" error shape is identical to what jobs already see on the write side.

`getInputFilesPath()` stays as the escape hatch for streaming or custom access (e.g. reading GCS objects through a stream). A CSV helper is intentionally out of scope — consumers can pass `readInputText()`'s result into their preferred parser in a single line, and we'll revisit when a concrete CSV consumer appears.

Also sweeps the surrounding docs to reflect the current File I/O surface: the README bullet and home-page feature card now describe read + write (rather than write-only artifact output), the cloud-jobs / integration guides list the readers in their one-line API summary, and the CLI-usage argument-prompts table plus the Zod-types reference both gain a note about `fileInput()` so the interactive picker is discoverable from those pages.

Scope: packages (gcp-job-runner)
Visibility: user-facing